### PR TITLE
Use of feature and presence

### DIFF
--- a/ietf-dhcpv6-client@2017-11-24.yang
+++ b/ietf-dhcpv6-client@2017-11-24.yang
@@ -13,7 +13,7 @@ module ietf-dhcpv6-client {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-04";
   }
 
   organization "DHC WG";
@@ -25,7 +25,13 @@ module ietf-dhcpv6-client {
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 client.";
-
+  
+  revision 2017-12-04{
+	  description "First version of the use of 
+		  feature and presence in options";
+	  reference "I-D:draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated client specific
       YANG model.";

--- a/ietf-dhcpv6-client@2017-11-24.yang
+++ b/ietf-dhcpv6-client@2017-11-24.yang
@@ -13,7 +13,7 @@ module ietf-dhcpv6-client {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-12-04";
+    revision-date "2017-11-24";
   }
 
   organization "DHC WG";
@@ -25,20 +25,19 @@ module ietf-dhcpv6-client {
 
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 client.";
-  
-  revision 2017-12-04{
-	  description "First version of the use of 
-		  feature and presence in options";
-	  reference "I-D:draft-ietf-dhc-dhcpv6-yang";
+
+	
+  revision 2017-11-29{
+	  description "First version of the seperation of Configuration
+		  and State trees.";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
   revision 2017-11-24 {
-    description "First version of the separated client specific
-      YANG model.";
-
-    reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+	    description "First version of the separated client specific
+	      YANG model.";
   }
-
+  
   /*
    * Grouping
    */
@@ -194,117 +193,126 @@ module ietf-dhcpv6-client {
    */
 
  container client {
-    presence "Enables client";
     description "dhcpv6 client portion";
-    container duid {
-      description "Sets the DUID";
-      uses duid;
-    }
-    list client-if {
-      key if-name;
-      description "A client may have several
-        interfaces, it is more reasonable to
-        configure and manage parameters on
-        the interface-level. The list defines
-        specific client interfaces and their
-        data. Different interfaces are distinguished
-        by the key which is a configurable string
-        value.";
-      leaf if-name {
-        type string;
-        mandatory true;
-        description "interface name";
-      }
-      leaf cli-id {
-        type uint32;
-        mandatory true;
-        description "client id";
-      }
-      leaf description {
-        type string;
-        description
-          "description of the client interface";
-      }
-      leaf pd-function {
-        type boolean;
-        mandatory true;
-        description "Whether the client
-          can act as a requesting router
-          to request prefixes using prefix
-          delegation ([RFC3633]).";
-      }
-      leaf rapid-commit {
-        type boolean;
-        mandatory true;
-        description "'1' indicates a client can initiate a Solicit-Reply
-          message exchange by adding a Rapid Commit option in Solicit
-          message. '0' means the client is not allowed to add a Rapid
-          Commit option to request addresses in a two-message exchange
-          pattern.";
-      }
-      container mo-tab {
-        description "The management tab label indicates the operation
-          mode of the DHCPv6 client. 'm'=1 and 'o'=1 indicate the
-          client will use DHCPv6 to obtain all the configuration data.
-          'm'=1 and 'o'=0 are a meaningless combination. 'm'=0 and 'o'=1
-          indicate the client will use stateless DHCPv6 to obtain
-          configuration data apart from addresses/prefixes data.
-          'm'=0 and 'o'=0 represent the client will not use DHCPv6
-          but use SLAAC to achieve configuration.";
-          // if - not sure about the intended use here as it seems
-          // to be redfining what will be received in the PIO. Is
-          // the intention to be whether they PIO options will be
-          // obeyed as received or overridden?
-        leaf m-tab {
-          type boolean;
-          mandatory true;
-          description "m tab";
-        }
-        leaf o-tab {
-          type boolean;
-          mandatory true;
-          description "o tab";
-        }
-      }
-      container client-configured-options {
-        description "client configured options";
-        uses dhcpv6-options:client-option-definitions;
-      }
-
-
-      container if-other-paras {
-        config "false";
-        description "A client can obtain
-          extra configuration data other than
-          address and prefix information through
-          DHCPv6. This container describes such
-          data the client was configured. The
-          potential configuration data may
-          include DNS server addresses, SIP
-          server domain names, etc.";
-        uses dhcpv6-options:server-option-definitions;
-
-        container supported-options {
-          // if - Unclear on what this container is used for. Maybe
-          // putting options as 'features' could replace this.
-          description "supported options";
-          list supported-option {
-            key option-code;
-            description "supported option";
-            leaf option-code {
-              type uint16;
+    
+    container client-config{
+    	description "configuration tree of client";
+    	
+        container duid {
+            description "Sets the DUID";
+            uses duid;
+          }
+          list client-if {
+            key if-name;
+            description "A client may have several
+              interfaces, it is more reasonable to
+              configure and manage parameters on
+              the interface-level. The list defines
+              specific client interfaces and their
+              data. Different interfaces are distinguished
+              by the key which is a configurable string
+              value.";
+            leaf if-name {
+              type string;
               mandatory true;
-              description "option code";
+              description "interface name";
+            }
+            leaf cli-id {
+              type uint32;
+              mandatory true;
+              description "client id";
             }
             leaf description {
               type string;
-              mandatory true;
               description
-                "description of supported option";
+                "description of the client interface";
+            }
+            leaf pd-function {
+              type boolean;
+              mandatory true;
+              description "Whether the client
+                can act as a requesting router
+                to request prefixes using prefix
+                delegation ([RFC3633]).";
+            }
+            leaf rapid-commit {
+              type boolean;
+              mandatory true;
+              description "'1' indicates a client can initiate a Solicit-Reply
+                message exchange by adding a Rapid Commit option in Solicit
+                message. '0' means the client is not allowed to add a Rapid
+                Commit option to request addresses in a two-message exchange
+                pattern.";
+            }
+            container mo-tab {
+              description "The management tab label indicates the operation
+                mode of the DHCPv6 client. 'm'=1 and 'o'=1 indicate the
+                client will use DHCPv6 to obtain all the configuration data.
+                'm'=1 and 'o'=0 are a meaningless combination. 'm'=0 and 'o'=1
+                indicate the client will use stateless DHCPv6 to obtain
+                configuration data apart from addresses/prefixes data.
+                'm'=0 and 'o'=0 represent the client will not use DHCPv6
+                but use SLAAC to achieve configuration.";
+                // if - not sure about the intended use here as it seems
+                // to be redfining what will be received in the PIO. Is
+                // the intention to be whether they PIO options will be
+                // obeyed as received or overridden?
+              leaf m-tab {
+                type boolean;
+                mandatory true;
+                description "m tab";
+              }
+              leaf o-tab {
+                type boolean;
+                mandatory true;
+                description "o tab";
+              }
+            }
+            container client-configured-options {
+              description "client configured options";
+              uses dhcpv6-options:client-option-definitions;
+            }
+    }
+    
+    
+    }
+    
+    container client-state{
+    	description "state tree of client";
+    	
+    	config "false";
+        container if-other-paras {
+            description "A client can obtain
+              extra configuration data other than
+              address and prefix information through
+              DHCPv6. This container describes such
+              data the client was configured. The
+              potential configuration data may
+              include DNS server addresses, SIP
+              server domain names, etc.";
+            uses dhcpv6-options:server-option-definitions;
+
+            container supported-options {
+              // if - Unclear on what this container is used for. Maybe
+              // putting options as 'features' could replace this.
+              description "supported options";
+              list supported-option {
+                key option-code;
+                description "supported option";
+                leaf option-code {
+                  type uint16;
+                  mandatory true;
+                  description "option code";
+                }
+                leaf description {
+                  type string;
+                  mandatory true;
+                  description
+                    "description of supported option";
+                }
+              }
             }
           }
-        }
-      }
     }
   }
 

--- a/ietf-dhcpv6-options@2017-11-24.yang
+++ b/ietf-dhcpv6-options@2017-11-24.yang
@@ -21,17 +21,33 @@ module ietf-dhcpv6-options {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
+  revision 2017-12-04{
+	  description "First version of the use of 
+		  feature and presence in options";
+	  reference "I-D:draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated DHCPv6 options
       YANG model.";
-
     reference "I-D:draft-ietf-dhc-dhcpv6-yang";
   }
 
   /*
    * Features
    */
-
+	feature server_op{
+		description "Support server options.";
+	}
+	
+	feature relay_op{
+		description "Support relay options.";
+	}
+	
+	feature client_op{
+		description "Support client options";
+	}
+	 
   /*
    * Groupings
    */
@@ -61,7 +77,9 @@ module ietf-dhcpv6-options {
   grouping server-option-definitions {
     description "Contains definitions for options configured on the
       DHCPv6 server which will be supplied to clients.";
+    
     container server-unicast-option {
+      if-feature server_op;
       description "OPTION_UNICAST (12) Server Unicast Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -69,23 +87,28 @@ module ietf-dhcpv6-options {
         type inet:ipv6-address;
       }
     }
+    
     container sip-server-option {
-      description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
+    	if-feature server_op;
+    	presence "Enable this option";
+    	description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
       and OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
       /* if - Note - this container is currently modelling two options
        (21 & 22). It would allow the config of a mixed list of domain
        names and addresses in a way that doesn't follow the
        RFC. Needs to be broken into SIP Domain list and SIP Address
        list containers */
-      reference "RFC3319: Dynamic Host Configuration Protocol
+    	reference "RFC3319: Dynamic Host Configuration Protocol
         (DHCPv6) Options for Session Initiation Protocol (SIP)
         Servers";
-      leaf enable {
+       
+ /*     leaf enable {
         type boolean;
         mandatory true;
         description "Indicate whether this option will be included in
           the option set";
-      }
+      }*/
+    	
       list sip-server {
         key sip-serv-id;
         description "sip server info";
@@ -108,17 +131,19 @@ module ietf-dhcpv6-options {
       }
     }
     container dns-config-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_DNS_SERVERS (23) DNS recursive Name
         Server option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
+/*      leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list dns-server {
         key dns-serv-id;
         description "dns server info";
@@ -135,16 +160,18 @@ module ietf-dhcpv6-options {
       }
     }
     container domain-searchlist-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_DOMAIN_LIST (24) Domain Search List Option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
+/*      leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       list domain-searchlist {
         key domain-searchlist-id;
         description "dns server info";
@@ -160,18 +187,21 @@ module ietf-dhcpv6-options {
         }
       }
     }
+    
     container nis-config-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_NIS_SERVERS (27) Network Information Service (NIS)
         Servers Option.";
       reference "RFC3989: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       list nis-server {
         key nis-serv-id;
         description "nis server info";
@@ -188,17 +218,19 @@ module ietf-dhcpv6-options {
       }
     }
     container nis-plus-config-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_NISP_SERVERS (28): Network Information Service V2
         (NIS+) Servers Option.";
       reference "RFC3989: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       list nis-plus-server {
         key nis-plus-serv-id;
         description "NIS+ server information.";
@@ -215,18 +247,20 @@ module ietf-dhcpv6-options {
       }
     }
     container nis-domain-name {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_NIS_DOMAIN_NAME (29) Network Information
         Service (NIS) Domain Name Option";
       reference "RFC3989: Network Information Service (NIS)
         Configuration Options for Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6)";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       leaf nis-domain-name {
         type string;
         description "The Network Information Service (NIS) Domain Name
@@ -235,17 +269,19 @@ module ietf-dhcpv6-options {
       }
     }
     container sntp-server-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_SNTP_SERVERS (31) Simple Network Time Protocol
         (SNTP) Servers Option";
       reference "RFC4075: Simple Network Time Protocol (SNTP) Configuration
         Option for DHCPv6";
-      leaf enable {
+  /*    leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list sntp-server {
         key sntp-serv-id;
         description "sntp server info";
@@ -262,17 +298,19 @@ module ietf-dhcpv6-options {
       }
     }
     container info-refresh-time-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_INFORMATION_REFRESH_TIME (32) Information Refresh
         Time option.";
       reference "RFC4242: Information Refresh Time Option for Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
          option will be included in the
          option set";
-      }
+      }*/
       leaf info-refresh-time {
         type yang:timeticks;
         mandatory true;
@@ -280,15 +318,17 @@ module ietf-dhcpv6-options {
       }
     }
     container cli-fqdn-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) DHCPv6 Client FQDN Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol for IPv6
         (DHCPv6) Client Fully Qualified Domain Name (FQDN) Option";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
           option set";
-      }
+      }*/
       leaf server-initiate-update {
         type boolean;
         mandatory true;
@@ -306,14 +346,16 @@ module ietf-dhcpv6-options {
       }
     }
     container posix-timezone-option {
+    	if-feature server_op;
+    	presence "Enable this option";
       description "OPTION_NEW_POSIX_TIMEZONE (41) Posix Timezone option";
       reference "RFC4822: Timezone Options for DHCP";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
           option set";
-      }
+      }*/
       leaf tz-posix {
         type string;
         mandatory true;
@@ -321,14 +363,16 @@ module ietf-dhcpv6-options {
       }
     }
     container posix-timezone-option-db-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_NEW_TZDB_TIMEZONE (42) Timezone Database option";
       reference "RFC4822: Timezone Options for DHCP";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
           option set";
-      }
+      }*/
       leaf tz-database {
         type string;
         mandatory true;
@@ -336,17 +380,19 @@ module ietf-dhcpv6-options {
       }
     }
     container ntp-server-option {
+      if-feature server_op;
+      presence "Enable this option";
       //This option looks like it needs work to correctly model the
       //option as defined in the RFC.
       description "OPTION_NTP_SERVER (56) NTP Server Option for DHCPv6";
       reference "RFC5908: Network Time Protocol (NTP) Server Option for
       DHCPv6";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
           option set";
-      }
+      }*/
       list ntp-server {
         key ntp-serv-id;
         description "ntp server info";
@@ -373,16 +419,18 @@ module ietf-dhcpv6-options {
       }
     }
     container network-boot-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPT_BOOTFILE_URL (59) and OPT_BOOTFILE_PARAM (60)";
       reference "RFC5970: DHCPv6 Options for Network Boot";
       // if - Looks like 2 options combined that need to be split out
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list boot-file {
         key boot-file-id;
         description "boot file info";
@@ -422,15 +470,17 @@ module ietf-dhcpv6-options {
       }
     }
     container aftr-name-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_AFTR_NAME (64) AFTR-Name DHCPv6 Option";
       reference "RFC6334: Dynamic Host Configuration Protocol for IPv6
       (DHCPv6) Option for Dual-Stack Lite";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
         option set";
-      }
+      } */
       leaf tunnel-endpoint-name {
         type string;
         mandatory true;
@@ -438,19 +488,21 @@ module ietf-dhcpv6-options {
       }
     }
     container kerberos-option {
+      if-feature server_op;
+      presence "Enable this option";
       //This needs re-working and possibly splitting into several option
       //containers to follow the RFC.
       description "OPTION_KRB_KDC (78) Kerberos KDB Option, OPTION_KRB_REALM_NAME (76)
         Kerberos Realm Name Option and OPTION_KRB_DEFAULT_REALM_NAME (77)
         Kerberos Default Realm Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       leaf default-realm-name {
         type string;
         mandatory true;
@@ -497,16 +549,18 @@ module ietf-dhcpv6-options {
       }
     }
     container sol-max-rt-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_SOL_MAX_RT (82) sol max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-        }
+        } */
         leaf sol-max-rt-value {
           type yang:timeticks;
           mandatory true;
@@ -514,16 +568,18 @@ module ietf-dhcpv6-options {
         }
     }
     container inf-max-rt-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_INF_MAX_RT (83) inf max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       leaf inf-max-rt-value {
         type yang:timeticks;
         mandatory true;
@@ -531,17 +587,19 @@ module ietf-dhcpv6-options {
       }
     }
     container addr-selection-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_ADDRSEL (84) and OPTION_ADDRSEL_TABLE (85)";
       reference "RFC7078: Distributing Address Selection Policy Using
       DHCPv6";
       // if - Needs checking to see if this matches the RFC - there
       // are two options here.
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
                   option set";
-        }
+        }*/
       leaf a-bit-set {
         type boolean;
         mandatory true;
@@ -583,16 +641,18 @@ module ietf-dhcpv6-options {
       }
     }
     container pcp-server-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_V6_PCP_SERVER (86)
         pcp server option";
       reference "RFC7291: DHCP Options for the Port Control
         Protocol (PCP)";
-      leaf enable {
+    /*  leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included
           in the option set";
-      }
+      } */
       list pcp-server {
         key pcp-serv-id;
         description "pcp server info";
@@ -609,15 +669,17 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-rule-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_S46_RULE (89) S46 rule option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
+    /*  leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included
           in the option set";
-      }
+      } */
       list s46-rule {
         key rule-id;
         description "s46 rule";
@@ -662,15 +724,17 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-br-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_S46_BR (90) S46 BR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included
           in the option set";
-      }
+      } */
       list br {
         key br-id;
         description "br info";
@@ -687,16 +751,18 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-dmr-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_S46_DMR (91) S46 DMR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list dmr {
         key dmr-id;
         description "dmr info";
@@ -718,17 +784,19 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-v4-v6-binding-option {
+      if-feature server_op;
+      presence "Enable this option";
       description "OPTION_S46_V4V6BIND (92) S46 IPv4/IPv6 Address
         Binding option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list ce {
         key ce-id;
         description "ce info";
@@ -764,6 +832,7 @@ module ietf-dhcpv6-options {
     description "Relay supplied DHCP Options";
     reference "RFC6422: Relay-Supplied DHCP Options";
     container erp-local-domain-name-option {
+      if-feature relay_op;	
       description "OPTION_ERP_LOCAL_DOMAIN_NAME (65) DHCPv6 ERP Local
         Domain Name Option";
       reference "RFC6440: The EAP Re-authentication Protocol (ERP)
@@ -830,9 +899,18 @@ module ietf-dhcpv6-options {
       }
     }
     container option-request-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_ORO (6) Option Request Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
+      /*   leaf enable {
+      type boolean;
+      mandatory true;
+      description "indicate whether this
+        option will be configured at the
+        client";
+    } */
       list oro-option {
         key option-code;
         description "oro option";
@@ -850,6 +928,7 @@ module ietf-dhcpv6-options {
       }
     }
     container rapid-commit-option {
+      if-feature client_op;
       description "OPTION_RAPID_COMMIT (14)";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -861,16 +940,18 @@ module ietf-dhcpv6-options {
       // defined there or as an option?
     }
     container user-class-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_USER_CLASS (15) User Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      leaf enable {
+   /*   leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      } */
       list user-class {
         key user-class-id;
         description "user class";
@@ -890,16 +971,18 @@ module ietf-dhcpv6-options {
       }
     }
     container vendor-class-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_VENDOR_CLASS (16) Vendor Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      leaf enable {
+    /*  leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      } */
       leaf enterprise-number {
         type uint32;
         mandatory true;
@@ -918,19 +1001,21 @@ module ietf-dhcpv6-options {
       }
     }
     container client-fqdn-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) The Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6) Client Fully
         Qualified Domain Name (FQDN) Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6) Client Fully Qualified Domain Name (FQDN)
         Option";
-      leaf enable {
+    /*  leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      } */
       leaf fqdn {
         type string;
         mandatory true;
@@ -948,16 +1033,18 @@ module ietf-dhcpv6-options {
       }
     }
     container client-arch-type-option {
+    	if-feature client_op;
+    	presence "Enable this option";
       description "OPTION_CLIENT_ARCH_TYPE (61) Client System
         Architecture Type Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-      leaf enable {
+   /*   leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      } */
       list architecture-types {
         key type-id;
         description "architecture types";
@@ -974,17 +1061,19 @@ module ietf-dhcpv6-options {
       }
     }
     container client-network-interface-identifier-option {
+      if-feature client_op;
+      presence "Enable this option";
       description
         "OPTION_NII (62) Client Network Interface Identifier
         Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      }*/
       leaf type {
         type uint8;
         mandatory true;
@@ -1002,16 +1091,18 @@ module ietf-dhcpv6-options {
       }
     }
     container krb-principal-name-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_KRB_PRINCIPAL_NAME (75) Kerberos
         Principal Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be configured at the
           client";
-      }
+      }*/
       leaf principal-name {
         type string;
         mandatory true;
@@ -1020,16 +1111,18 @@ module ietf-dhcpv6-options {
       }
     }
     container client-link-layer-addr-option {
+      if-feature client_op;
+      presence "Enable this option";
       description "OPTION_CLIENT_LINKLAYER_ADDR (79) DHCPv6 Client
         Link-Layer Address Option";
       reference "RFC6939: Client Link-Layer Address Option in
         DHCPv6";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be configured
           at the client";
-      }
+      }*/
       leaf link-layer-type {
         type uint16;
         mandatory true;
@@ -1047,15 +1140,17 @@ module ietf-dhcpv6-options {
 
   grouping custom-option-definitions {
     container operator-option-ipv6-address {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator ipv6 address option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       list operator-ipv6-addr {
         key operator-ipv6-addr-id;
         description "operator ipv6 address info";
@@ -1072,16 +1167,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-single-flag {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator single flag";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+    /*  leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list flag {
         key flag-id;
         description "operator single flag info";
@@ -1098,16 +1195,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-ipv6-prefix {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator ipv6 prefix option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list operator-ipv6-prefix{
         key operator-ipv6-prefix-id;
         description "operator ipv6 prefix info";
@@ -1129,16 +1228,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int32 {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator integer 32 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list int32val{
         key int32val-id;
         description "operator integer 32 info";
@@ -1155,16 +1256,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int16 {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator integer 16 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list int16val{
         key int16val-id;
         description "operator integer 16 info";
@@ -1181,16 +1284,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int8 {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator integer 8 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list int8val{
         key int8val-id;
         description "operator integer 8 info";
@@ -1207,16 +1312,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-uri {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator uri option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+   /*   leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list uri{
         key uri-id;
         description "operator uri info";
@@ -1233,15 +1340,17 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-textstring {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator itext string option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
+   /*   leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list textstring{
         key textstring-id;
         description "operator text string info";
@@ -1258,15 +1367,17 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-var-data {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator variable length data option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
+      /*leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      }*/
       list int32val{
         key var-data-id;
         description "operator ivariable length data info";
@@ -1283,16 +1394,18 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-dns-wire {
+      if-feature server_op;
+      presence "Enable this option";
       description "operator dns wire format domain name list option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
+     /* leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this
           option will be included in the
           option set";
-      }
+      } */
       list operator-option-dns-wire{
         key operator-option-dns-wire-id;
         description "operator dns wire format info";

--- a/ietf-dhcpv6-options@2017-11-24.yang
+++ b/ietf-dhcpv6-options@2017-11-24.yang
@@ -21,33 +21,171 @@ module ietf-dhcpv6-options {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
-  revision 2017-12-04{
-	  description "First version of the use of 
-		  feature and presence in options";
-	  reference "I-D:draft-ietf-dhc-dhcpv6-yang";
-  }
-  
   revision 2017-11-24 {
     description "First version of the separated DHCPv6 options
       YANG model.";
+
     reference "I-D:draft-ietf-dhc-dhcpv6-yang";
   }
 
   /*
    * Features
    */
-	feature server_op{
-		description "Support server options.";
+	feature server-unicast-op {
+		description "Support for Server Unicast option";
+	}
+	feature sip-server-op {
+		description "Support for SIP Server option";
+	}
+	feature dns-configuration-op {
+		description "Support for DNS Recursive Name Server option";
+	}
+	feature domain-searchlist-op {
+		description "Support for Domain Search List Option";
+	}
+	feature nis-config-op {
+		description "Support for Network Information Service (NIS)
+			Servers option";
+	}
+	feature nis-plus-config-op {
+		description "Support for Network Information Service V2 (NIS+) 
+			Servers option";
+	}
+  	feature nis-domain-name-op {
+  		description "Support for Network Information Service (NIS)
+  			Domain Name option";
+  	}
+  	feature nis-plus-domain-name-op {
+  		description "Support for Network Information Service V2 (NIS+)
+  			Server option";
+  	}
+  	feature sntp-server-op {
+  		description "Support for Simple Network Protocol Configuration 
+  			(SNTP) Servers option";
+  	}
+  	feature info-refresh-time-op {
+  		description "Support for Information Refresh Time option";
+  	}
+  	feature cli-fqdn-op {
+  		description "Support for Client FQDN option";
+  	}
+  	feature posix-timezone-op {
+  		description "Support for New POIX Timezone option";
+  	}
+  	feature tzdb-timezone-op {
+  		description "Support for New TZDB Timezone option";
+  	}
+  	feature ntp-server-op {
+  		description "Support for Network Time Protocol (NTP) 
+  			Server option";
+  	}
+  	feature network-boot-op {
+  		description "Support for Network Boot option";
+  	}
+  	feature aftr-boot-op {
+  		description "Support for Address Family Transition
+  			Router (AFTR) option";
+  	}
+  	feature kerberos-op {
+  		description "Support for Kerberos options";
+  	}
+  	feature sol-max-rt-op {
+  		description "Support for SOL_MAX_RT option";
+  	}
+  	feature inf-max-rt-op {
+  		description "Support for INF_MAX_RT option";
+  	}
+  	feature addr-selection-op {
+  		description "Support for Address Selection opiton";
+  	}
+  	feature pcp-op {
+  		description "Support for Port Control Protocol (PCP)
+  			option";
+  	}
+  	feature s46-rule-op {
+  		description "Support for S46 Rule option";
+  	}
+  	feature s46-br-op {
+  		description "Support for S46 Border Relay (BR) option";
+  	}
+  	feature s46-dmr-op {
+  		description "Support for S46 Default Mapping Rule 
+  			(DMR) option";
+  	}
+  	feature s46-v4-v6-binding-op {
+  		description "Support for S46 IPv4/IPv6 Address
+  			Bind option";
+  	}
+  	feature erp-local-domain-name-op {
+  		description "Support for ERP Local Domain
+  			Name option";
+  	}
+  	feature option-request-op {
+  		description "Support for Option Request
+  			option";
+  	}
+  	feature rapid-commit-op {
+  		description "Support for Rapid Commit option";
+  	}
+  	feature user-class-op {
+  		description "Support for User Class option";
+  	}
+  	feature vendor-class-op {
+  		description "Support for Vendor Class option";
+  	}
+  	feature client-arch-type-op {
+  		description "Support for Client System Architecture
+  			Type option";
+  	}
+  	feature client-network-interface-identifier-op {
+  		description "Support for Client Network Interface
+  			Identifier option";
+  	}
+  	feature krb-principal-name-op {
+  		description "Support for Kerberos Principal
+  			Name option";
+  	}
+  	feature client-link-layer-addr-op {
+  		description "Support for Client Link-Layer Address
+  			Option";
+  	}
+  	feature operator-op-ipv6-address {
+  		description "Support for Option with IPv6 Addresses";
+  	}
+  	feature operator-op-single-flag {
+  		description "Support for Option with Single Flag";
+  	}
+  	feature operator-op-ipv6-prefix {
+  		description "Support for Option with IPv6 Prefix";
+  	}
+	feature operator-op-int32 {
+		description "Support for Opion with 32-bit
+			Integer Value";
+	}
+	feature operator-op-int16 {
+		description "Support for Opion with 16-bit
+			Integer Value";
+	}
+	feature operator-op-int8 {
+		description "Support for Opion with 8-bit
+			Integer Value";
+	}
+	feature operator-op-uri {
+		description "Support for Opion with URI";
+	}
+	feature operator-op-textstring {
+		description "Support for Opion with Text
+			String";
+	}
+	feature operator-op-var-data {
+		description "Support for Opion with 
+			Variable-Length Data";
+	}
+	feature operator-op-dns-wire {
+		description "Support for Opion with DNS Wire
+			Format Domain Name List";
 	}
 	
-	feature relay_op{
-		description "Support relay options.";
-	}
-	
-	feature client_op{
-		description "Support client options";
-	}
-	 
   /*
    * Groupings
    */
@@ -77,9 +215,8 @@ module ietf-dhcpv6-options {
   grouping server-option-definitions {
     description "Contains definitions for options configured on the
       DHCPv6 server which will be supplied to clients.";
-    
     container server-unicast-option {
-      if-feature server_op;
+      if-feature server-unicast-op;
       description "OPTION_UNICAST (12) Server Unicast Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -87,28 +224,19 @@ module ietf-dhcpv6-options {
         type inet:ipv6-address;
       }
     }
-    
     container sip-server-option {
-    	if-feature server_op;
-    	presence "Enable this option";
-    	description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
+      if-feature sip-server-op;
+      presence "Enable this option";
+      description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
       and OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
       /* if - Note - this container is currently modelling two options
        (21 & 22). It would allow the config of a mixed list of domain
        names and addresses in a way that doesn't follow the
        RFC. Needs to be broken into SIP Domain list and SIP Address
        list containers */
-    	reference "RFC3319: Dynamic Host Configuration Protocol
+      reference "RFC3319: Dynamic Host Configuration Protocol
         (DHCPv6) Options for Session Initiation Protocol (SIP)
         Servers";
-       
- /*     leaf enable {
-        type boolean;
-        mandatory true;
-        description "Indicate whether this option will be included in
-          the option set";
-      }*/
-    	
       list sip-server {
         key sip-serv-id;
         description "sip server info";
@@ -131,19 +259,12 @@ module ietf-dhcpv6-options {
       }
     }
     container dns-config-option {
-      if-feature server_op;
+      if-feature dns-config-op;
       presence "Enable this option";
       description "OPTION_DNS_SERVERS (23) DNS recursive Name
         Server option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-/*      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list dns-server {
         key dns-serv-id;
         description "dns server info";
@@ -160,18 +281,11 @@ module ietf-dhcpv6-options {
       }
     }
     container domain-searchlist-option {
-      if-feature server_op;
+      if-feature dns-searchlist-op;
       presence "Enable this option";
       description "OPTION_DOMAIN_LIST (24) Domain Search List Option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-/*      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       list domain-searchlist {
         key domain-searchlist-id;
         description "dns server info";
@@ -187,21 +301,13 @@ module ietf-dhcpv6-options {
         }
       }
     }
-    
     container nis-config-option {
-      if-feature server_op;
+      if-feature nis-config-op;
       presence "Enable this option";
       description "OPTION_NIS_SERVERS (27) Network Information Service (NIS)
         Servers Option.";
-      reference "RFC3989: Network Information Service (NIS) Configuration
+      reference "RFC3898: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       list nis-server {
         key nis-serv-id;
         description "nis server info";
@@ -218,19 +324,12 @@ module ietf-dhcpv6-options {
       }
     }
     container nis-plus-config-option {
-      if-feature server_op;
+      if-feature nis-plus-config-op;
       presence "Enable this option";
       description "OPTION_NISP_SERVERS (28): Network Information Service V2
         (NIS+) Servers Option.";
       reference "RFC3989: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       list nis-plus-server {
         key nis-plus-serv-id;
         description "NIS+ server information.";
@@ -246,21 +345,14 @@ module ietf-dhcpv6-options {
         }
       }
     }
-    container nis-domain-name {
-      if-feature server_op;
+    container nis-domain-name-option {
+      if-feature nis-domain-name-op;
       presence "Enable this option";
       description "OPTION_NIS_DOMAIN_NAME (29) Network Information
         Service (NIS) Domain Name Option";
       reference "RFC3989: Network Information Service (NIS)
         Configuration Options for Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6)";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       leaf nis-domain-name {
         type string;
         description "The Network Information Service (NIS) Domain Name
@@ -268,20 +360,28 @@ module ietf-dhcpv6-options {
         info to the client.";
       }
     }
+    container nis-plus-domain-name-option {
+        if-feature nis-plus-domain-name-op;
+        presence "Enable this option";
+        description "OPTION_NISP_DOMAIN_NAME (30) Network Information 
+          Service V2 (NIS+) Domain Name Option";
+        reference "RFC3989: Network Information Service (NIS)
+          Configuration Options for Dynamic Host Configuration Protocol
+          for IPv6 (DHCPv6)";
+        leaf nis-plus-domain-name {
+          type string;
+          description "The Network Information Service V2 (NIS+) Domain Name
+          option is used by the server to convey client's NIS+ Domain Name
+          info to the client.";
+        }
+      }
     container sntp-server-option {
-      if-feature server_op;
+      if-feature sntp-server-op;
       presence "Enable this option";
       description "OPTION_SNTP_SERVERS (31) Simple Network Time Protocol
         (SNTP) Servers Option";
       reference "RFC4075: Simple Network Time Protocol (SNTP) Configuration
         Option for DHCPv6";
-  /*    leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list sntp-server {
         key sntp-serv-id;
         description "sntp server info";
@@ -298,19 +398,12 @@ module ietf-dhcpv6-options {
       }
     }
     container info-refresh-time-option {
-      if-feature server_op;
-      presence "Enable this option";
+      if-feature info-refresh-op;
+      presence "Enable this option";	
       description "OPTION_INFORMATION_REFRESH_TIME (32) Information Refresh
         Time option.";
       reference "RFC4242: Information Refresh Time Option for Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-         option will be included in the
-         option set";
-      }*/
       leaf info-refresh-time {
         type yang:timeticks;
         mandatory true;
@@ -318,17 +411,11 @@ module ietf-dhcpv6-options {
       }
     }
     container cli-fqdn-option {
-      if-feature server_op;
+      if-feature cli-fqdn-op;
       presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) DHCPv6 Client FQDN Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol for IPv6
         (DHCPv6) Client Fully Qualified Domain Name (FQDN) Option";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }*/
       leaf server-initiate-update {
         type boolean;
         mandatory true;
@@ -346,53 +433,35 @@ module ietf-dhcpv6-options {
       }
     }
     container posix-timezone-option {
-    	if-feature server_op;
-    	presence "Enable this option";
+      if-feature posix-timezone-op;
+      presence "Enable this option";
       description "OPTION_NEW_POSIX_TIMEZONE (41) Posix Timezone option";
-      reference "RFC4822: Timezone Options for DHCP";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }*/
+      reference "RFC4833: Timezone Options for DHCP";
       leaf tz-posix {
         type string;
         mandatory true;
         description "TZ Posix IEEE 1003.1 String";
       }
     }
-    container posix-timezone-option-db-option {
-      if-feature server_op;
+    container tzdb-timezone-option {
+      if-feature tzbd-timezone-op;
       presence "Enable this option";
       description "OPTION_NEW_TZDB_TIMEZONE (42) Timezone Database option";
       reference "RFC4822: Timezone Options for DHCP";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }*/
       leaf tz-database {
         type string;
         mandatory true;
         description "Reference to the TZ Database";
       }
-    }
+    }  
     container ntp-server-option {
-      if-feature server_op;
-      presence "Enable this option";
       //This option looks like it needs work to correctly model the
       //option as defined in the RFC.
+      if-feature ntp-server-op;
+      presence "Enable this option";
       description "OPTION_NTP_SERVER (56) NTP Server Option for DHCPv6";
       reference "RFC5908: Network Time Protocol (NTP) Server Option for
       DHCPv6";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }*/
       list ntp-server {
         key ntp-serv-id;
         description "ntp server info";
@@ -419,18 +488,11 @@ module ietf-dhcpv6-options {
       }
     }
     container network-boot-option {
-      if-feature server_op;
-      presence "Enable this option";
       description "OPT_BOOTFILE_URL (59) and OPT_BOOTFILE_PARAM (60)";
       reference "RFC5970: DHCPv6 Options for Network Boot";
       // if - Looks like 2 options combined that need to be split out
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
+      if-feature network-boot-op;
+      presence "Enable this option";
       list boot-file {
         key boot-file-id;
         description "boot file info";
@@ -470,17 +532,11 @@ module ietf-dhcpv6-options {
       }
     }
     container aftr-name-option {
-      if-feature server_op;
+      if-feature aftr-name-op;
       presence "Enable this option";
       description "OPTION_AFTR_NAME (64) AFTR-Name DHCPv6 Option";
       reference "RFC6334: Dynamic Host Configuration Protocol for IPv6
       (DHCPv6) Option for Dual-Stack Lite";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-        option set";
-      } */
       leaf tunnel-endpoint-name {
         type string;
         mandatory true;
@@ -488,21 +544,14 @@ module ietf-dhcpv6-options {
       }
     }
     container kerberos-option {
-      if-feature server_op;
-      presence "Enable this option";
       //This needs re-working and possibly splitting into several option
       //containers to follow the RFC.
+      if-feature kerberos-op;
+      presence "Enable this option";
       description "OPTION_KRB_KDC (78) Kerberos KDB Option, OPTION_KRB_REALM_NAME (76)
         Kerberos Realm Name Option and OPTION_KRB_DEFAULT_REALM_NAME (77)
         Kerberos Default Realm Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       leaf default-realm-name {
         type string;
         mandatory true;
@@ -549,18 +598,11 @@ module ietf-dhcpv6-options {
       }
     }
     container sol-max-rt-option {
-      if-feature server_op;
+      if-feature sol-max-rt-op;
       presence "Enable this option";
       description "OPTION_SOL_MAX_RT (82) sol max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-        } */
         leaf sol-max-rt-value {
           type yang:timeticks;
           mandatory true;
@@ -568,18 +610,11 @@ module ietf-dhcpv6-options {
         }
     }
     container inf-max-rt-option {
-      if-feature server_op;
+      if-feature inf-max-rt-op;
       presence "Enable this option";
       description "OPTION_INF_MAX_RT (83) inf max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       leaf inf-max-rt-value {
         type yang:timeticks;
         mandatory true;
@@ -587,19 +622,19 @@ module ietf-dhcpv6-options {
       }
     }
     container addr-selection-option {
-      if-feature server_op;
+      if-feature addr-selection-op;
       presence "Enable this option";
       description "OPTION_ADDRSEL (84) and OPTION_ADDRSEL_TABLE (85)";
       reference "RFC7078: Distributing Address Selection Policy Using
       DHCPv6";
       // if - Needs checking to see if this matches the RFC - there
       // are two options here.
-      /*leaf enable {
+      leaf enable {
         type boolean;
         mandatory true;
         description "indicate whether this option will be included in the
                   option set";
-        }*/
+        }
       leaf a-bit-set {
         type boolean;
         mandatory true;
@@ -641,18 +676,12 @@ module ietf-dhcpv6-options {
       }
     }
     container pcp-server-option {
-      if-feature server_op;
+      if-feature pcp-server-op;
       presence "Enable this option";
       description "OPTION_V6_PCP_SERVER (86)
         pcp server option";
       reference "RFC7291: DHCP Options for the Port Control
         Protocol (PCP)";
-    /*  leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      } */
       list pcp-server {
         key pcp-serv-id;
         description "pcp server info";
@@ -669,17 +698,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-rule-option {
-      if-feature server_op;
+      if-feature s46-rule-op;
       presence "Enable this option";
       description "OPTION_S46_RULE (89) S46 rule option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-    /*  leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      } */
       list s46-rule {
         key rule-id;
         description "s46 rule";
@@ -724,17 +747,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-br-option {
-      if-feature server_op;
+      if-feature s46-br-op;
       presence "Enable this option";
       description "OPTION_S46_BR (90) S46 BR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      } */
       list br {
         key br-id;
         description "br info";
@@ -751,18 +768,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-dmr-option {
-      if-feature server_op;
+      if-feature s46-dmr-op;
       presence "Enable this option";
       description "OPTION_S46_DMR (91) S46 DMR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list dmr {
         key dmr-id;
         description "dmr info";
@@ -784,19 +794,12 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-v4-v6-binding-option {
-      if-feature server_op;
+      if-feature s46-v4-v6-binding-op;
       presence "Enable this option";
       description "OPTION_S46_V4V6BIND (92) S46 IPv4/IPv6 Address
         Binding option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list ce {
         key ce-id;
         description "ce info";
@@ -832,18 +835,12 @@ module ietf-dhcpv6-options {
     description "Relay supplied DHCP Options";
     reference "RFC6422: Relay-Supplied DHCP Options";
     container erp-local-domain-name-option {
-      if-feature relay_op;	
+      if-feature erp-local-domain-name-op;
+      presence "Enable this option";
       description "OPTION_ERP_LOCAL_DOMAIN_NAME (65) DHCPv6 ERP Local
         Domain Name Option";
       reference "RFC6440: The EAP Re-authentication Protocol (ERP)
         Local Domain Name DHCPv6 Option";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether
-          this option is included in the
-          rsoo set";
-      }
       list erp-for-client {
         key cli-id;
         description "erp for client";
@@ -899,18 +896,11 @@ module ietf-dhcpv6-options {
       }
     }
     container option-request-option {
-      if-feature client_op;
+      if-feature option-request-op;
       presence "Enable this option";
       description "OPTION_ORO (6) Option Request Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      /*   leaf enable {
-      type boolean;
-      mandatory true;
-      description "indicate whether this
-        option will be configured at the
-        client";
-    } */
       list oro-option {
         key option-code;
         description "oro option";
@@ -928,7 +918,7 @@ module ietf-dhcpv6-options {
       }
     }
     container rapid-commit-option {
-      if-feature client_op;
+      if-feature rapid-commmit-op;
       description "OPTION_RAPID_COMMIT (14)";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -940,18 +930,11 @@ module ietf-dhcpv6-options {
       // defined there or as an option?
     }
     container user-class-option {
-      if-feature client_op;
+      if-feature user-class-op;
       presence "Enable this option";
       description "OPTION_USER_CLASS (15) User Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-   /*   leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      } */
       list user-class {
         key user-class-id;
         description "user class";
@@ -971,18 +954,11 @@ module ietf-dhcpv6-options {
       }
     }
     container vendor-class-option {
-      if-feature client_op;
+      if-feature vendor-class-op;
       presence "Enable this option";
       description "OPTION_VENDOR_CLASS (16) Vendor Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-    /*  leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      } */
       leaf enterprise-number {
         type uint32;
         mandatory true;
@@ -1001,7 +977,7 @@ module ietf-dhcpv6-options {
       }
     }
     container client-fqdn-option {
-      if-feature client_op;
+      if-feature cli-fqdn-op;
       presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) The Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6) Client Fully
@@ -1009,13 +985,6 @@ module ietf-dhcpv6-options {
       reference "RFC4704: The Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6) Client Fully Qualified Domain Name (FQDN)
         Option";
-    /*  leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      } */
       leaf fqdn {
         type string;
         mandatory true;
@@ -1033,18 +1002,11 @@ module ietf-dhcpv6-options {
       }
     }
     container client-arch-type-option {
-    	if-feature client_op;
-    	presence "Enable this option";
+      if-feature client-arch-type-op;
+      presence "Enable this option";
       description "OPTION_CLIENT_ARCH_TYPE (61) Client System
         Architecture Type Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-   /*   leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      } */
       list architecture-types {
         key type-id;
         description "architecture types";
@@ -1061,19 +1023,12 @@ module ietf-dhcpv6-options {
       }
     }
     container client-network-interface-identifier-option {
-      if-feature client_op;
+      if-feature client-network-interface-identifier-op;
       presence "Enable this option";
       description
         "OPTION_NII (62) Client Network Interface Identifier
         Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }*/
       leaf type {
         type uint8;
         mandatory true;
@@ -1091,18 +1046,11 @@ module ietf-dhcpv6-options {
       }
     }
     container krb-principal-name-option {
-      if-feature client_op;
+      if-feature krb-principal-name-op;
       presence "Enable this option";
       description "OPTION_KRB_PRINCIPAL_NAME (75) Kerberos
         Principal Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }*/
       leaf principal-name {
         type string;
         mandatory true;
@@ -1111,18 +1059,12 @@ module ietf-dhcpv6-options {
       }
     }
     container client-link-layer-addr-option {
-      if-feature client_op;
+      if-feature client-link-layer-addr-op;
       presence "Enable this option";
       description "OPTION_CLIENT_LINKLAYER_ADDR (79) DHCPv6 Client
         Link-Layer Address Option";
       reference "RFC6939: Client Link-Layer Address Option in
         DHCPv6";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be configured
-          at the client";
-      }*/
       leaf link-layer-type {
         type uint16;
         mandatory true;
@@ -1140,17 +1082,10 @@ module ietf-dhcpv6-options {
 
   grouping custom-option-definitions {
     container operator-option-ipv6-address {
-      if-feature server_op;
+      if-feature operator-op-ipv6-address;
       presence "Enable this option";
       description "operator ipv6 address option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       list operator-ipv6-addr {
         key operator-ipv6-addr-id;
         description "operator ipv6 address info";
@@ -1167,18 +1102,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-single-flag {
-      if-feature server_op;
+      if-feature operator-op-single-flag;
       presence "Enable this option";
       description "operator single flag";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-    /*  leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list flag {
         key flag-id;
         description "operator single flag info";
@@ -1195,18 +1123,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-ipv6-prefix {
-      if-feature server_op;
+      if-feature operator-op-ipv6-prefix;
       presence "Enable this option";
       description "operator ipv6 prefix option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list operator-ipv6-prefix{
         key operator-ipv6-prefix-id;
         description "operator ipv6 prefix info";
@@ -1228,18 +1149,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int32 {
-      if-feature server_op;
+      if-feature operator-op-int32;
       presence "Enable this option";
       description "operator integer 32 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list int32val{
         key int32val-id;
         description "operator integer 32 info";
@@ -1256,18 +1170,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int16 {
-      if-feature server_op;
+      if-feature operator-op-int16;
       presence "Enable this option";
       description "operator integer 16 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list int16val{
         key int16val-id;
         description "operator integer 16 info";
@@ -1284,18 +1191,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int8 {
-      if-feature server_op;
+      if-feature operator-op-int8;
       presence "Enable this option";
       description "operator integer 8 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list int8val{
         key int8val-id;
         description "operator integer 8 info";
@@ -1312,18 +1212,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-uri {
-      if-feature server_op;
+      if-feature operator-op-uri;
       presence "Enable this option";
       description "operator uri option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-   /*   leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list uri{
         key uri-id;
         description "operator uri info";
@@ -1340,17 +1233,10 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-textstring {
-      if-feature server_op;
+      if-feature operator-op-textstring;
       presence "Enable this option";
       description "operator itext string option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-   /*   leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list textstring{
         key textstring-id;
         description "operator text string info";
@@ -1367,17 +1253,10 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-var-data {
-      if-feature server_op;
+      if-feature operator-op-var-data;
       presence "Enable this option";
       description "operator variable length data option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      /*leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }*/
       list int32val{
         key var-data-id;
         description "operator ivariable length data info";
@@ -1394,18 +1273,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-dns-wire {
-      if-feature server_op;
+      if-feature operator-op-dns-wire;
       presence "Enable this option";
       description "operator dns wire format domain name list option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-     /* leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      } */
       list operator-option-dns-wire{
         key operator-option-dns-wire-id;
         description "operator dns wire format info";

--- a/ietf-dhcpv6-options@2017-11-24.yang
+++ b/ietf-dhcpv6-options@2017-11-24.yang
@@ -37,7 +37,7 @@ module ietf-dhcpv6-options {
 	feature sip-server-op {
 		description "Support for SIP Server option";
 	}
-	feature dns-configuration-op {
+	feature dns-config-op {
 		description "Support for DNS Recursive Name Server option";
 	}
 	feature domain-searchlist-op {
@@ -82,7 +82,7 @@ module ietf-dhcpv6-options {
   	feature network-boot-op {
   		description "Support for Network Boot option";
   	}
-  	feature aftr-boot-op {
+  	feature aftr-name-op {
   		description "Support for Address Family Transition
   			Router (AFTR) option";
   	}
@@ -98,7 +98,7 @@ module ietf-dhcpv6-options {
   	feature addr-selection-op {
   		description "Support for Address Selection opiton";
   	}
-  	feature pcp-op {
+  	feature pcp-server-op {
   		description "Support for Port Control Protocol (PCP)
   			option";
   	}
@@ -281,7 +281,7 @@ module ietf-dhcpv6-options {
       }
     }
     container domain-searchlist-option {
-      if-feature dns-searchlist-op;
+      if-feature domain-searchlist-op;
       presence "Enable this option";
       description "OPTION_DOMAIN_LIST (24) Domain Search List Option";
       reference "RFC3646: DNS Configuration options for Dynamic
@@ -398,7 +398,7 @@ module ietf-dhcpv6-options {
       }
     }
     container info-refresh-time-option {
-      if-feature info-refresh-op;
+      if-feature info-refresh-time-op;
       presence "Enable this option";	
       description "OPTION_INFORMATION_REFRESH_TIME (32) Information Refresh
         Time option.";
@@ -444,7 +444,7 @@ module ietf-dhcpv6-options {
       }
     }
     container tzdb-timezone-option {
-      if-feature tzbd-timezone-op;
+      if-feature tzdb-timezone-op;
       presence "Enable this option";
       description "OPTION_NEW_TZDB_TIMEZONE (42) Timezone Database option";
       reference "RFC4822: Timezone Options for DHCP";
@@ -918,7 +918,7 @@ module ietf-dhcpv6-options {
       }
     }
     container rapid-commit-option {
-      if-feature rapid-commmit-op;
+      if-feature rapid-commit-op;
       description "OPTION_RAPID_COMMIT (14)";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";

--- a/ietf-dhcpv6-relay@2017-11-24.yang
+++ b/ietf-dhcpv6-relay@2017-11-24.yang
@@ -9,7 +9,7 @@ module ietf-dhcpv6-relay {
 
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-04";
   }
 
   organization "DHC WG";
@@ -22,10 +22,15 @@ module ietf-dhcpv6-relay {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 relay.";
 
+  revision 2017-12-04{
+	  description "First version of the use of 
+		  feature and presence in options";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated relay specific
       YANG model.";
-
     reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
 

--- a/ietf-dhcpv6-relay@2017-11-24.yang
+++ b/ietf-dhcpv6-relay@2017-11-24.yang
@@ -9,7 +9,7 @@ module ietf-dhcpv6-relay {
 
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-12-04";
+    revision-date "2017-11-24";
   }
 
   organization "DHC WG";
@@ -22,15 +22,16 @@ module ietf-dhcpv6-relay {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 relay.";
 
-  revision 2017-12-04{
-	  description "First version of the use of 
-		  feature and presence in options";
-	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+  revision 2017-11-29{
+	  description "separation of relay configuration and 
+		  state trees";
+	  reference "I-d: draft-ietf-dhc-dhcpv6-yang";
   }
   
   revision 2017-11-24 {
     description "First version of the separated relay specific
       YANG model.";
+
     reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
 
@@ -59,319 +60,348 @@ module ietf-dhcpv6-relay {
    */
 
 container relay {
-    presence "Enables relay";
     description "dhcpv6 relay portion";
-    container relay-attributes {
-      description "A container describes
-        some basic attributes of the relay
-        agent including some relay agent
-        specific options data that need to
-        be configured previously. Such options
-        include Remote-Id option and
-        Subscriber-Id option.";
-      leaf name {
-        type string;
-        description "relay agent name";
-      }
-      leaf description {
-        type string;
-        description "description of the relay agent";
-      }
-      leaf-list dest-addrs {
-        type inet:ipv6-address;
-        description "Each DHCPv6 relay agent may
-          be configured with a list of destination
-          addresses. This node defines such a list
-          of IPv6 addresses that may include
-          unicast addresses, multicast addresses
-          or other addresses.";
-      }
-      list subscribers {
-        key subscriber;
-        description "subscribers";
-        leaf subscriber {
-          type uint8;
-          mandatory true;
-          description "subscriber";
-        }
-        leaf subscriber-id {
-          type string;
-          mandatory true;
-          description "subscriber id";
-        }
-      }
-      list remote-host {
-        key ent-num;
-        description "remote host";
-        leaf ent-num {
-          type uint32;
-          mandatory true;
-          description "enterprise number";
-        }
-        leaf remote-id {
-          type string;
-          mandatory true;
-          description "remote id";
-        }
-      }
-      uses vendor-infor;
-    }
+    
+    container relay-config{
+    	description "configuration tree of relay";
+    	
+        container relay-attributes {
+            description "A container describes
+              some basic attributes of the relay
+              agent including some relay agent
+              specific options data that need to
+              be configured previously. Such options
+              include Remote-Id option and
+              Subscriber-Id option.";
+            leaf name {
+              type string;
+              description "relay agent name";
+            }
+            leaf description {
+              type string;
+              description "description of the relay agent";
+            }
+            leaf-list dest-addrs {
+              type inet:ipv6-address;
+              description "Each DHCPv6 relay agent may
+                be configured with a list of destination
+                addresses. This node defines such a list
+                of IPv6 addresses that may include
+                unicast addresses, multicast addresses
+                or other addresses.";
+            }
+            list subscribers {
+              key subscriber;
+              description "subscribers";
+              leaf subscriber {
+                type uint8;
+                mandatory true;
+                description "subscriber";
+              }
+              leaf subscriber-id {
+                type string;
+                mandatory true;
+                description "subscriber id";
+              }
+            }
+            list remote-host {
+              key ent-num;
+              description "remote host";
+              leaf ent-num {
+                type uint32;
+                mandatory true;
+                description "enterprise number";
+              }
+              leaf remote-id {
+                type string;
+                mandatory true;
+                description "remote id";
+              }
+            }
+            uses vendor-infor;
+          }
 
-    container rsoo-option-sets {
-      list option-set {
-        key id;
-          leaf id {
-            type uint32;
+          container rsoo-option-sets {
+            list option-set {
+              key id;
+                leaf id {
+                  type uint32;
+                }
+              uses dhcpv6-options:relay-supplied-option-definitions;
+            }
           }
-        uses dhcpv6-options:relay-supplied-option-definitions;
-      }
-    }
 
-    list relay-if {
-      // if - This should reference an entry in ietf-interfaces
-      key if-name;
-      description "A relay agent may have several
-        interfaces, we should provide a way to configure
-        and manage parameters on the interface-level. A
-        list that describes specific interfaces and
-        their corresponding parameters is employed to
-        fulfil the configfuration. Here we use a string
-        called 'if-name; as the key of list.";
-      leaf if-name {
-        type string;
-        mandatory true;
-        description "interface name";
-      }
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description
-          "whether this interface is enabled";
-      }
-      leaf ipv6-address {
-        type inet:ipv6-address;
-        description
-          "ipv6 address for this interface";
-      }
-      leaf interface-id {
-        type string;
-        description "interface id";
-      }
-      leaf rsoo-option-set-id {
-        type leafref {
-          path "/relay/rsoo-option-sets/option-set/id";
-        }
-        description "Configured Relay Supplied Option set";
-      }
-      list pd-route {
-        // if - need to look at if/how we model these. If they are
-        // going to be modelled, then they should be ro state
-        // entries (we're not trying to configure routes here)
-        key pd-route-id;
-        description "pd route";
-        leaf pd-route-id {
-          type uint8;
-          mandatory true;
-          description "pd route id";
-        }
-        leaf requesting-router-id {
-          type uint32;
-          mandatory true;
-          description "requesting router id";
-        }
-        leaf delegating-router-id {
-          type uint32;
-          mandatory true;
-          description "delegating router id";
-        }
-        leaf next-router {
-          type inet:ipv6-address;
-          mandatory true;
-          description "next router";
-        }
-        leaf last-router {
-          type inet:ipv6-address;
-          mandatory true;
-          description "previous router";
-        }
-      }
-      list next-entity {
-        key dest-addr;
-        description "This node defines
-          a list that is used to describe
-          the next hop entity of this
-          relay distinguished by their
-          addresses.";
-        leaf dest-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "destination addr";
-        }
-        leaf available {
-          type boolean;
-          mandatory true;
-          description "whether the next entity
-            is available or not";
-        }
-        leaf multicast {
-          type boolean;
-          mandatory true;
-          description "whether the address is
-            multicast or not";
-        }
-        leaf server {
-          type boolean;
-          mandatory true;
-          description "whether the next entity
-            is a server";
-        }
-        container packet-stats {
-          config "false";
-          description "packet statistics";
-          leaf cli-packet-rvd-count {
-            type uint32;
-            mandatory true;
-            description "client received packet
-              counter";
+          list relay-if {
+            // if - This should reference an entry in ietf-interfaces
+            key if-name;
+            description "A relay agent may have several
+              interfaces, we should provide a way to configure
+              and manage parameters on the interface-level. A
+              list that describes specific interfaces and
+              their corresponding parameters is employed to
+              fulfil the configfuration. Here we use a string
+              called 'if-name; as the key of list.";
+            leaf if-name {
+              type string;
+              mandatory true;
+              description "interface name";
+            }
+            leaf enable {
+              type boolean;
+              mandatory true;
+              description
+                "whether this interface is enabled";
+            }
+            leaf ipv6-address {
+              type inet:ipv6-address;
+              description
+                "ipv6 address for this interface";
+            }
+            leaf interface-id {
+              type string;
+              description "interface id";
+            }
+            leaf rsoo-option-set-id {
+              type leafref {
+                path "/relay/relay-config/rsoo-option-sets/option-set/id";
+              }
+              description "Configured Relay Supplied Option set";
+            }
+            list pd-route {
+              // if - need to look at if/how we model these. If they are
+              // going to be modelled, then they should be ro state
+              // entries (we're not trying to configure routes here)
+              key pd-route-id;
+              description "pd route";
+              leaf pd-route-id {
+                type uint8;
+                mandatory true;
+                description "pd route id";
+              }
+              leaf requesting-router-id {
+                type uint32;
+                mandatory true;
+                description "requesting router id";
+              }
+              leaf delegating-router-id {
+                type uint32;
+                mandatory true;
+                description "delegating router id";
+              }
+              leaf next-router {
+                type inet:ipv6-address;
+                mandatory true;
+                description "next router";
+              }
+              leaf last-router {
+                type inet:ipv6-address;
+                mandatory true;
+                description "previous router";
+              }
+            }
+            list next-entity {
+              key dest-addr;
+              description "This node defines
+                a list that is used to describe
+                the next hop entity of this
+                relay distinguished by their
+                addresses.";
+              leaf dest-addr {
+                type inet:ipv6-address;
+                mandatory true;
+                description "destination addr";
+              }
+              leaf available {
+                type boolean;
+                mandatory true;
+                description "whether the next entity
+                  is available or not";
+              }
+              leaf multicast {
+                type boolean;
+                mandatory true;
+                description "whether the address is
+                  multicast or not";
+              }
+              leaf server {
+                type boolean;
+                mandatory true;
+                description "whether the next entity
+                  is a server";
+              }
+            }
           }
-          leaf solicit-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "solicit received counter";
-          }
-          leaf request-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "request received counter";
-          }
-          leaf renew-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "renew received counter";
-          }
-          leaf rebind-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "rebind recevied counter";
-          }
-          leaf decline-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "decline received counter";
-          }
-          leaf release-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "release received counter";
-          }
-          leaf info-req-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "information request counter";
-          }
-          leaf relay-for-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay forward received counter";
-          }
-          leaf relay-rep-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay reply received counter";
-          }
-          leaf packet-to-cli-count {
-            type uint32;
-            mandatory true;
-            description
-              "packet to client counter";
-          }
-          leaf adver-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "advertisement sent counter";
-          }
-          leaf confirm-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "confirm sent counter";
-          }
-          leaf reply-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "reply sent counter";
-          }
-          leaf reconfig-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "reconfigure sent counter";
-          }
-          leaf relay-for-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay forward sent counter";
-          }
-          leaf relay-rep-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay reply sent counter";
-          }
-        }
-      }
+          
+    	
     }
-    container relay-stats {
-      config "false";
-      description "relay statistics";
-      leaf cli-packet-rvd-count {
-        type uint32;
-        mandatory true;
-        description "client packet received counter";
-      }
-      leaf relay-for-rvd-count {
-        type uint32;
-        mandatory true;
-        description "relay forward received counter";
-      }
-      leaf relay-rep-rvd-count {
-        type uint32;
-        mandatory true;
-        description "relay reply recevied counter";
-      }
-      leaf packet-to-cli-count {
-        type uint32;
-        mandatory true;
-        description "packet to client counter";
-      }
-      leaf relay-for-sent-count {
-        type uint32;
-        mandatory true;
-        description "relay forward sent counter";
-      }
-      leaf relay-rep-sent-count {
-        type uint32;
-        mandatory true;
-        description "relay reply sent counter";
-      }
-      leaf discarded-packet-count {
-        type uint32;
-        mandatory true;
-        description "discarded packet counter";
-      }
-    }
+    
+    
+	container relay-state{
+		description "state tree of relay";
+		
+		config "false";
+		list relay-if{
+			key if-name;
+			description "...";			
+			leaf if-name{
+				type string;
+				mandatory true;
+				description "interface name";
+			}
+			list next-entity{
+				key dest-addr;
+				leaf dest-addr{
+					type inet:ipv6-address;
+					mandatory true;
+					description "destination addr";
+				}
+				container packet-stats {
+					description "packet statistics";
+					leaf solicit-rvd-count {
+		                  type uint32;
+		                  mandatory true;
+		                  description
+		                    "solicit received counter";
+		                }
+	                leaf request-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "request received counter";
+	                }
+	                leaf renew-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "renew received counter";
+	                }
+	                leaf rebind-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "rebind recevied counter";
+	                }
+	                leaf decline-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "decline received counter";
+	                }
+	                leaf release-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "release received counter";
+	                }
+	                leaf info-req-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "information request counter";
+	                }
+	                leaf relay-for-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay forward received counter";
+	                }
+	                leaf relay-rep-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay reply received counter";
+	                }
+	                leaf packet-to-cli-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "packet to client counter";
+	                }
+	                leaf adver-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "advertisement sent counter";
+	                }
+	                leaf confirm-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "confirm sent counter";
+	                }
+	                leaf reply-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "reply sent counter";
+	                }
+	                leaf reconfig-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "reconfigure sent counter";
+	                }
+	                leaf relay-for-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay forward sent counter";
+	                }
+	                leaf relay-rep-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay reply sent counter";
+	                }
+				}
+				
+			}
+		}
+		
+		
+	    container relay-stats {
+	        config "false";
+	        description "relay statistics";
+	        leaf cli-packet-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "client packet received counter";
+	        }
+	        leaf relay-for-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay forward received counter";
+	        }
+	        leaf relay-rep-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay reply recevied counter";
+	        }
+	        leaf packet-to-cli-count {
+	          type uint32;
+	          mandatory true;
+	          description "packet to client counter";
+	        }
+	        leaf relay-for-sent-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay forward sent counter";
+	        }
+	        leaf relay-rep-sent-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay reply sent counter";
+	        }
+	        leaf discarded-packet-count {
+	          type uint32;
+	          mandatory true;
+	          description "discarded packet counter";
+	        }
+	      }
+		
+	}
+    
+
   }
 
   /*

--- a/ietf-dhcpv6-server@2017-11-24.yang
+++ b/ietf-dhcpv6-server@2017-11-24.yang
@@ -12,7 +12,7 @@ module ietf-dhcpv6-server {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-12-04";
+    revision-date "2017-11-24";
   }
 
   organization "DHC WG";
@@ -25,9 +25,9 @@ module ietf-dhcpv6-server {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
-  revision 2017-12-04{
-	  description "First version of the use of 
-		  feature and presence in options";
+  revision 2017-11-29 {
+	  description "First version of separation of server configuration
+		  and state trees.";
 	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
   
@@ -75,6 +75,7 @@ module ietf-dhcpv6-server {
      }
    }
   }
+  
 
   grouping duid {
     description "DHCP Unique Identifier";
@@ -134,641 +135,691 @@ module ietf-dhcpv6-server {
    */
 
   container server {
-    presence "Enables server";
     description "dhcpv6 server portion";
-    container serv-attributes {
-      description "This container contains basic attributes
-        of a DHCPv6 server such as DUID, server name and so
-        on. Some optional functions that can be provided by
-        the server is also included.";
-      leaf name {
-        type string;
-        description "server's name";
-      }
-      container duid {
-        description "Sets the DUID";
-        uses duid;
-      }
-      leaf-list ipv6-address {
-        type inet:ipv6-address;
-        description "Server's IPv6 address.";
-      }
-      leaf description {
-        type string;
-        description "Description of the server.";
-      }
-      leaf pd-function {
-        type boolean;
-        mandatory true;
-        description "Whether the server can act as a
-          delegating router to perform prefix delegation
-          ([RFC3633]).";
-      }
-      leaf stateless-service {
-        type boolean;
-        mandatory true;
-        description "A boolean value specifies whether
-          the server support client-server exchanges
-          involving two messages defined in ([RFC3315]).";
-      }
-      leaf rapid-commit {
-        type boolean;
-        mandatory true;
-        description "A boolean value specifies whether
-          the server support client-server exchanges
-          involving two messages defined in ([RFC3315]).";
-      }
-      leaf-list interfaces-config {
-        // Note - this should probably be references to
-        // entries in the ietf-interfaces model
-        type string;
-        description "A leaf list to denote which one or
-          more interfaces the server should listen on. The
-          default value is to listen on all the interfaces.
-          This node is also used to set a unicast address
-          for the server to listen with a specific interface.
-            For example, if people want the server to listen
-              on a unicast address with a specific interface, he
-              can use the format like 'eth1/2001:db8::1'.";
-      }
-      uses vendor-infor;
-    }
+    
+    /*configuration data*/
+    container server-config{
+    	description "configuration tree of server";
+    	   container serv-attributes {
+    		      description "This container contains basic attributes
+    		        of a DHCPv6 server such as DUID, server name and so
+    		        on. Some optional functions that can be provided by
+    		        the server is also included.";
+    		      leaf name {
+    		        type string;
+    		        description "server's name";
+    		      }
+    		      container duid {
+    		        description "Sets the DUID";
+    		        uses duid;
+    		      }
+    		      leaf-list ipv6-address {
+    		        type inet:ipv6-address;
+    		        description "Server's IPv6 address.";
+    		      }
+    		      leaf description {
+    		        type string;
+    		        description "Description of the server.";
+    		      }
+    		      leaf pd-function {
+    		        type boolean;
+    		        mandatory true;
+    		        description "Whether the server can act as a
+    		          delegating router to perform prefix delegation
+    		          ([RFC3633]).";
+    		      }
+    		      leaf stateless-service {
+    		        type boolean;
+    		        mandatory true;
+    		        description "A boolean value specifies whether
+    		          the server support client-server exchanges
+    		          involving two messages defined in ([RFC3315]).";
+    		      }
+    		      leaf rapid-commit {
+    		        type boolean;
+    		        mandatory true;
+    		        description "A boolean value specifies whether
+    		          the server support client-server exchanges
+    		          involving two messages defined in ([RFC3315]).";
+    		      }
+    		      leaf-list interfaces-config {
+    		        // Note - this should probably be references to
+    		        // entries in the ietf-interfaces model
+    		        type string;
+    		        description "A leaf list to denote which one or
+    		          more interfaces the server should listen on. The
+    		          default value is to listen on all the interfaces.
+    		          This node is also used to set a unicast address
+    		          for the server to listen with a specific interface.
+    		            For example, if people want the server to listen
+    		              on a unicast address with a specific interface, he
+    		              can use the format like 'eth1/2001:db8::1'.";
+    		      }
+    		      uses vendor-infor;
+    		    }
+    	
+    	    container option-sets {
+    	        list option-set {
+    	          key id;
+    	            leaf id {
+    	              type uint32;
+    	            }
+    	          uses dhcpv6-options:server-option-definitions;
+    	          uses dhcpv6-options:custom-option-definitions;
+    	        }
+    	      }
 
-    container option-sets {
-      list option-set {
-        key id;
-          leaf id {
-            type uint32;
-          }
-        uses dhcpv6-options:server-option-definitions;
-        uses dhcpv6-options:custom-option-definitions;
-      }
+    	      container network-ranges {
+    	        description "This model supports a hierarchy
+    	          to achieve dynamic configuration. That is to
+    	          say we could configure the server at different
+    	          levels through this model. The top level is a
+    	          global level which is defined as the container
+    	          'network-ranges'. The following levels are
+    	          defined as sub-containers under it. The
+    	          'network-ranges' contains the parameters
+    	          (e.g. option-sets) that would be allocated to
+    	          all the clients served by this server.";
+    	        list network-range {
+    	          key network-range-id;
+    	          description "Under the 'network-ranges'
+    	            container, a 'network-range' list is
+    	            defined to configure the server at a
+    	            network level which is also considered
+    	            as the second level. Different network
+    	            are identified by the key 'network-range-id'.
+    	            This is because a server may have different
+    	            configuration parameters (e.g. option sets)
+    	            for different networks.";
+    	          leaf network-range-id {
+    	            type uint32;
+    	            mandatory true;
+    	            description "equivalent to subnet id";
+    	          }
+    	          leaf network-description {
+    	            type string;
+    	            mandatory true;
+    	            description "description of the subnet";
+    	          }
+    	          leaf network-prefix {
+    	            type inet:ipv6-prefix;
+    	            mandatory true;
+    	            description "subnet prefix";
+    	          }
+    	          leaf inherit-option-set {
+    	            type boolean;
+    	            mandatory true;
+    	            description "indicate whether to inherit
+    	              the configuration from higher level";
+    	          }
+    	          leaf option-set-id {
+    	            type leafref {
+    	              path "/server/server-config/option-sets/option-set/id";
+    	            }
+    	            description "The ID field of relevant option-set to be
+    	              provisioned to clients of this network-range.";
+    	          }
+    	        }
+    	          container reserved-addresses {
+    	            description "reserved addresses";
+    	            list static-binding {
+    	              key cli-id;
+    	              description "static binding of
+    	                reserved addresses";
+    	              leaf cli-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "client id";
+    	              }
+    	              container duid {
+    	                description "Sets the DUID";
+    	                uses duid;
+    	              }
+    	              leaf-list reserv-addr {
+    	                type inet:ipv6-address;
+    	                description "reserved addr";
+    	              }
+    	            }
+    	            leaf-list other-reserv-addr {
+    	              type inet:ipv6-address;
+    	              description "other reserved
+    	                addr";
+    	            }
+    	          }
+    	          container reserved-prefixes {
+    	            description "reserved prefixes";
+    	            list static-binding {
+    	              key cli-id;
+    	              description "static binding";
+    	              leaf cli-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "client id";
+    	              }
+    	              container duid {
+    	                description "Sets the DUID";
+    	                uses duid;
+    	              }
+    	              leaf reserv-prefix-len {
+    	                type uint8;
+    	                mandatory true;
+    	                description "reserved
+    	                  prefix length";
+    	              }
+    	              leaf reserv-prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix";
+    	              }
+    	            }
+    	            leaf exclude-prefix-len {
+    	              type uint8;
+    	              mandatory true;
+    	              description "exclude prefix
+    	                length";
+    	            }
+    	            leaf exclude-prefix {
+    	              type inet:ipv6-prefix;
+    	              mandatory true;
+    	              description "exclude prefix";
+    	            }
+    	            list other-reserv-prefix {
+    	              key reserv-id;
+    	              description
+    	                "other reserved prefix";
+    	              leaf reserv-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix id";
+    	              }
+    	              leaf prefix-len {
+    	                type uint8;
+    	                mandatory true;
+    	                description "prefix length";
+    	              }
+    	              leaf prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix";
+    	              }
+    	            }
+    	          }
+    	          container address-pools {
+    	            description "A container describes
+    	              the DHCPv6 server's address pools.";
+    	            list address-pool {
+    	              key pool-id;
+    	              description "A DHCPv6 server can
+    	                be configured with several address
+    	                pools. This list defines such
+    	                address pools which are distinguish
+    	                by the key called 'pool-name'.";
+    	              leaf pool-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "pool id";
+    	              }
+    	              leaf pool-prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description "pool prefix";
+    	              }
+    	              leaf start-address {
+    	                type inet:ipv6-address-no-zone;
+    	                mandatory true;
+    	                description "start address";
+    	              }
+    	              leaf end-address {
+    	                type inet:ipv6-address-no-zone;
+    	                mandatory true;
+    	                description "end address";
+    	              }
+    	              leaf renew-time {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "renew time";
+    	              }
+    	              leaf rebind-time {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "rebind time";
+    	              }
+    	              leaf preferred-lifetime {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "preferred lifetime
+    	                  for IA";
+    	              }
+    	              leaf valid-lifetime {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "valid liftime for IA";
+    	              }
+    	              leaf utilization-ratio {
+    	                type threshold;
+    	                mandatory true;
+    	                description "the utilization ratio";
+    	              }
+    	              leaf inherit-option-set {
+    	                type boolean;
+    	                mandatory true;
+    	                description "indicate whether to
+    	                  inherit the configuration from
+    	                  higher level";
+    	              }
+    	              leaf option-set-id {
+    	                type leafref {
+    	                	path "/server/server-config/option-sets/option-set/id";
+    	                }
+    	                mandatory true;
+    	                description "The ID field of relevant option-set to be
+    	                  provisioned to clients of this address-pool.";
+    	              }
+    	          }    	               	                	            
+    	        }
+    	          
+    	          container prefix-pools {
+      	            description "If a server supports prefix
+      	              delegation function, this container will
+      	              be used to define the delegating router's
+      	              refix pools.";
+      	            list prefix-pool {
+      	              key pool-id;
+      	              description "Similar to server's
+      	                address pools, a delegating router
+      	                can also be configured with multiple
+      	                prefix pools specified by a list
+      	                called 'prefix-pool'.";
+      	              leaf pool-id {
+      	                type uint32;
+      	                mandatory true;
+      	                description "pool id";
+      	              }
+      	              leaf prefix {
+      	            	  
+      	                type inet:ipv6-prefix;
+      	                mandatory true;
+      	                description "ipv6 prefix";
+      	              }
+      	              leaf prefix-length {
+      	                type uint8;
+      	                mandatory true;
+      	                description "prefix length";
+      	              }
+      	              leaf renew-time {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "renew time";
+      	              }
+      	              leaf rebind-time {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "rebind time";
+      	              }
+      	              leaf preferred-lifetime {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "preferred lifetime for
+      	                  IA";
+      	              }
+      	              leaf valid-lifetime {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "valid lifetime for IA";
+      	              }
+      	              leaf utilization-ratio {
+      	                type threshold;
+      	                mandatory true;
+      	                description "utilization ratio";
+      	              }
+      	              leaf inherit-option-set {
+      	                type boolean;
+      	                mandatory true;
+      	                description "whether to inherit
+      	                  configuration from higher level";
+      	              }
+      	              leaf option-set-id {
+      	                type leafref {
+      	                	path "/server/server-config/option-sets/option-set/id";
+      	                }
+      	                description "The ID field of relevant option-set to be
+      	                  provisioned to clients of this prefix-pool.";
+      	              }
+      	            }
+      	          }
+      	          container hosts {
+      	            description "hosts level";
+      	            list host {
+      	              key cli-id;
+      	              description "specific host";
+      	              leaf cli-id {
+      	                type uint32;
+      	                mandatory true;
+      	                description "client id";
+      	              }
+      	              container duid {
+      	                description "Sets the DUID";
+      	                uses duid;
+      	              }
+      	              leaf inherit-option-set {
+      	                type boolean;
+      	                mandatory true;
+      	                description "whether to inherit
+      	                  configuration
+      	                  from higher level";
+      	              }
+      	              leaf option-set-id {
+      	                type leafref {
+      	                	path "/server/server-config/option-sets/option-set/id";
+      	                }
+      	                description "The ID field of relevant option-set to be
+      	                  provisioned to clients of this prefix-pool.";
+      	              }
+      	              leaf nis-domain-name {
+      	                type string;
+      	                description "nis domain name";
+      	              }
+      	              leaf nis-plus-domain-name {
+      	                type string;
+      	                description "nisp domain name";
+      	              }
+      	            }
+      	          }
+    	      }
+    	      container relay-opaque-paras {
+    	        description "This container contains some
+    	          opaque values in Relay Agent options that
+    	          need to be configured on the server side
+    	          only for value match. Such Relay Agent
+    	          options include Interface-Id option,
+    	                  Remote-Id option and Subscriber-Id option.";
+    	        list relays {
+    	          key relay-name;
+    	          description "relay agents";
+    	          leaf relay-name {
+    	            type string;
+    	            mandatory true;
+    	            description "relay agent name";
+    	          }
+    	          list interface-info {
+    	            key if-name;
+    	            description "interface info";
+    	            leaf if-name {
+    	              type string;
+    	              mandatory true;
+    	              description "interface name";
+    	            }
+    	            leaf interface-id {
+    	              type string;
+    	              mandatory true;
+    	              description "interface id";
+    	            }
+    	          }
+    	          list subscribers {
+    	            key subscriber;
+    	            description "subscribers";
+    	            leaf subscriber {
+    	              type uint32;
+    	              mandatory true;
+    	              description "subscriber";
+    	            }
+    	            leaf subscriber-id {
+    	              type string;
+    	              mandatory true;
+    	              description "subscriber id";
+    	            }
+    	          }
+    	          list remote-host {
+    	            key ent-num;
+    	            description "remote host";
+    	            leaf ent-num {
+    	              type uint32;
+    	              mandatory true;
+    	              description "enterprise number";
+    	            }
+    	            leaf remote-id {
+    	              type string;
+    	              mandatory true;
+    	              description "remote id";
+    	            }
+    	          }
+    	        }
+    	      }
+    	      container rsoo-enabled-options {
+    	        description "rsoo enabled options";
+    	        list rsoo-enabled-option{
+    	          key option-code;
+    	          description "rsoo enabled option";
+    	          leaf option-code {
+    	            type uint16;
+    	            mandatory true;
+    	            description "option code";
+    	          }
+    	          leaf description {
+    	            type string;
+    	            mandatory true;
+    	            description "description of the option";
+    	          }
+    	        }
+    	      }
+    	
     }
-
-    container network-ranges {
-      description "This model supports a hierarchy
-        to achieve dynamic configuration. That is to
-        say we could configure the server at different
-        levels through this model. The top level is a
-        global level which is defined as the container
-        'network-ranges'. The following levels are
-        defined as sub-containers under it. The
-        'network-ranges' contains the parameters
-        (e.g. option-sets) that would be allocated to
-        all the clients served by this server.";
-      list network-range {
-        key network-range-id;
-        description "Under the 'network-ranges'
-          container, a 'network-range' list is
-          defined to configure the server at a
-          network level which is also considered
-          as the second level. Different network
-          are identified by the key 'network-range-id'.
-          This is because a server may have different
-          configuration parameters (e.g. option sets)
-          for different networks.";
-        leaf network-range-id {
-          type uint32;
-          mandatory true;
-          description "equivalent to subnet id";
-        }
-        leaf network-description {
-          type string;
-          mandatory true;
-          description "description of the subnet";
-        }
-        leaf network-prefix {
-          type inet:ipv6-prefix;
-          mandatory true;
-          description "subnet prefix";
-        }
-        leaf inherit-option-set {
-          type boolean;
-          mandatory true;
-          description "indicate whether to inherit
-            the configuration from higher level";
-        }
-        leaf option-set-id {
-          type leafref {
-            path "/server/option-sets/option-set/id";
-          }
-          description "The ID field of relevant option-set to be
-            provisioned to clients of this network-range.";
-        }
-      }
-        container reserved-addresses {
-          description "reserved addresses";
-          list static-binding {
-            key cli-id;
-            description "static binding of
-              reserved addresses";
-            leaf cli-id {
+      
+    /*State data*/
+    container server-state{
+    	config "false";
+    	description "states of server";
+    	 	
+    	container network-ranges{   		
+    		list network-range{
+    			key network-range-id;
+    			leaf network-range-id {
+    	            type uint32;
+    	            mandatory true;
+    	            description "equivalent to subnet id";
+    	          }
+  	            description "The ID field of relevant option-set to be
+  	              provisioned to clients of this network-range.";
+  	          
+    			
+    			
+        		container address-pools{
+        			description "A container that describes
+        				the DHCPv6 server's address pools";   			
+            		list address-pool{
+            			key pool-id;
+    	              	leaf pool-id {
+        	                type uint32;
+        	                mandatory true;
+        	                description "pool id";
+        	              }
+            			description "...";
+            			leaf total-ipv6-count{
+            				type uint64;
+            				mandatory true;
+            				description "how many ipv6 addresses
+            					are in the pool";
+            			}
+            			leaf used-ipv6-count{
+            				type uint64;
+            				mandatory true;
+            				description "how many are allocated";
+            			}
+            			leaf utilization-ratio{
+            				type threshold;
+            				mandatory true;
+            				description "the utilization ratio";
+            			}
+            		}
+            		list binding-info {
+            			key cli-id;
+            			description "A list that records a binding
+            				information for each DHCPv6 client 
+            				that has already been allocated 
+            				IPv6 addresses.";
+            			leaf cli-id{
+            				type uint32;
+            				mandatory true;
+            				description "client id";
+            				
+            			}
+            			container duid {
+            				description "Read the DUID";
+            				uses duid;
+            			}
+            			list cli-ia{
+            				key iaid;
+            				description "client IA";
+            				leaf ia-type{
+            					type string;
+            					mandatory true;
+            					description "IA type";
+            				}
+            				leaf iaid{
+            					type uint32;
+            					mandatory true;
+            					description "IAID";
+            				}
+            				leaf-list cli-addr{
+            					type inet:ipv6-address;
+            					description "client addr";
+            				}
+            				leaf pool-id{
+            					type uint32;
+            					mandatory true;
+            					description "pool id";
+            				}
+            			}
+            		}
+        		}    		
+        		container prefix-pools{
+        			description "If a server supports prefix
+        				delegation function, this container will
+        				be used to define the delegating router's 
+        				prefix pools.";
+        			list binding-info{
+        				key cli-id;
+        				description "A list records a binding
+        					information for each DHCPv6 client
+        					that has already been alloated IPv6
+        					addresses.";
+        				leaf cli-id{
+        					type uint32;
+        					mandatory true;
+        					description "client id";
+        				}
+        				container duid{
+        					description "Reads the DUID";
+        					uses duid;
+        				}
+        				list cli-iapd{
+        					key iaid;
+        					description "client IAPD";
+        					leaf iaid{
+        						type uint32;
+        						mandatory true;
+        						description "IAID";
+        					}   					
+        					leaf-list cli-prefix {
+        						type inet:ipv6-prefix;
+        						description "client ipv6 prefix";
+        					}    					
+        					leaf-list cli-prefix-len{
+        						type uint8;
+        						description "client prefix length";
+        					}    					
+        					leaf pool-id{
+        						type uint32;
+        						mandatory true;
+        						description "pool id";
+        					}
+        					
+        				}
+        			}
+        		}    
+    		}
+    		}
+		    		
+    	
+    	
+        container packet-stats {
+              description "A container presents
+              the packet statistics related to
+              the DHCPv6 server.";
+            leaf solicit-count {
               type uint32;
               mandatory true;
-              description "client id";
+              description "solicit counter";
             }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf-list reserv-addr {
-              type inet:ipv6-address;
-              description "reserved addr";
-            }
-          }
-          leaf-list other-reserv-addr {
-            type inet:ipv6-address;
-            description "other reserved
-              addr";
-          }
-        }
-        container reserved-prefixes {
-          description "reserved prefixes";
-          list static-binding {
-            key cli-id;
-            description "static binding";
-            leaf cli-id {
+            leaf request-count {
               type uint32;
               mandatory true;
-              description "client id";
+              description "request counter";
             }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf reserv-prefix-len {
-              type uint8;
-              mandatory true;
-              description "reserved
-                prefix length";
-            }
-            leaf reserv-prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description
-                "reserved prefix";
-            }
-          }
-          leaf exclude-prefix-len {
-            type uint8;
-            mandatory true;
-            description "exclude prefix
-              length";
-          }
-          leaf exclude-prefix {
-            type inet:ipv6-prefix;
-            mandatory true;
-            description "exclude prefix";
-          }
-          list other-reserv-prefix {
-            key reserv-id;
-            description
-              "other reserved prefix";
-            leaf reserv-id {
+            leaf renew-count {
               type uint32;
               mandatory true;
-              description
-                "reserved prefix id";
+              description "renew counter";
             }
-            leaf prefix-len {
-              type uint8;
-              mandatory true;
-              description "prefix length";
-            }
-            leaf prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description
-                "reserved prefix";
-            }
-          }
-        }
-        container address-pools {
-          description "A container describes
-            the DHCPv6 server's address pools.";
-          list address-pool {
-            key pool-id;
-            description "A DHCPv6 server can
-              be configured with several address
-              pools. This list defines such
-              address pools which are distinguish
-              by the key called 'pool-name'.";
-            leaf pool-id {
+            leaf rebind-count {
               type uint32;
               mandatory true;
-              description "pool id";
+              description "rebind counter";
             }
-            leaf pool-prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description "pool prefix";
-            }
-            leaf start-address {
-              type inet:ipv6-address-no-zone;
-              mandatory true;
-              description "start address";
-            }
-            leaf end-address {
-              type inet:ipv6-address-no-zone;
-              mandatory true;
-              description "end address";
-            }
-            leaf renew-time {
-              type yang:timeticks;
-              mandatory true;
-              description "renew time";
-            }
-            leaf rebind-time {
-              type yang:timeticks;
-              mandatory true;
-              description "rebind time";
-            }
-            leaf preferred-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "preferred lifetime
-                for IA";
-            }
-            leaf valid-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "valid liftime for IA";
-            }
-            leaf total-ipv6-count {
-              type uint64;
-              config "false";
-              mandatory true;
-              description "how many ipv6
-                addressses are in the pool";
-            }
-            leaf used-ipv6-count {
-              type uint64;
-              config "false";
-              mandatory true;
-              description "how many are
-                allocated";
-            }
-            leaf utilization-ratio {
-              type threshold;
-              mandatory true;
-              description "the utilization ratio";
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "indicate whether to
-                inherit the configuration from
-                higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
-              }
-              mandatory true;
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this address-pool.";
-            }
-          list binding-info {
-            key cli-id;
-            config "false";
-            description "A list records a binding
-              information for each DHCPv6 client
-              that has already been allocated IPv6
-              addresses.";
-            leaf cli-id {
+            leaf decline-count {
               type uint32;
               mandatory true;
-              description "client id";
+              description "decline count";
             }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
+            leaf release-count {
+              type uint32;
+              mandatory true;
+              description "release counter";
             }
-            list cli-ia {
-              key iaid;
-              description "client IA";
-              leaf ia-type {
-                type string;
-                mandatory true;
-                description "IA type";
-              }
-              leaf iaid {
-                type uint32;
-                mandatory true;
-                description "IAID";
-              }
-              leaf-list cli-addr {
-                type inet:ipv6-address;
-                description "client addr";
-              }
-              leaf pool-id {
-                type uint32;
-                mandatory true;
-                description "pool id";
-              }
+            leaf info-req-count {
+              type uint32;
+              mandatory true;
+              description "information request
+                counter";
+            }
+            leaf advertise-count {
+              type uint32;
+              mandatory true;
+              description "advertise counter";
+            }
+            leaf confirm-count {
+              type uint32;
+              mandatory true;
+              description "confirm counter";
+            }
+            leaf reply-count {
+              type uint32;
+              mandatory true;
+              description "reply counter";
+            }
+            leaf reconfigure-count {
+              type uint32;
+              mandatory true;
+              description "reconfigure counter";
+            }
+            leaf relay-forward-count {
+              type uint32;
+              mandatory true;
+              description "relay forward counter";
+            }
+            leaf relay-reply-count {
+              type uint32;
+              mandatory true;
+              description "relay reply counter";
             }
           }
         }
-
-      }
-        container prefix-pools {
-            description "If a server supports prefix
-              delegation function, this container will
-              be used to define the delegating router's
-              refix pools.";
-            list prefix-pool {
-              key pool-id;
-              description "Similar to server's
-                address pools, a delegating router
-                can also be configured with multiple
-                prefix pools specified by a list
-                called 'prefix-pool'.";
-              leaf pool-id {
-                type uint32;
-                mandatory true;
-                description "pool id";
-              }
-              leaf prefix {
-                type inet:ipv6-prefix;
-                mandatory true;
-                description "ipv6 prefix";
-              }
-              leaf prefix-length {
-                type uint8;
-                mandatory true;
-                description "prefix length";
-              }
-              leaf renew-time {
-                type yang:timeticks;
-                mandatory true;
-                description "renew time";
-              }
-              leaf rebind-time {
-                type yang:timeticks;
-                mandatory true;
-                description "rebind time";
-              }
-              leaf preferred-lifetime {
-                type yang:timeticks;
-                mandatory true;
-                description "preferred lifetime for
-                  IA";
-              }
-              leaf valid-lifetime {
-                type yang:timeticks;
-                mandatory true;
-                description "valid lifetime for IA";
-              }
-              leaf utilization-ratio {
-                type threshold;
-                mandatory true;
-                description "utilization ratio";
-              }
-              leaf inherit-option-set {
-                type boolean;
-                mandatory true;
-                description "whether to inherit
-                  configuration from higher level";
-              }
-              leaf option-set-id {
-                type leafref {
-                  path "/server/option-sets/option-set/id";
-                }
-                description "The ID field of relevant option-set to be
-                  provisioned to clients of this prefix-pool.";
-              }
-            }
-            list binding-info {
-              key cli-id;
-              config "false";
-              description "A list records a
-                binding information for each
-                DHCPv6 client that has already
-                been allocated IPv6 addresses.";
-              leaf cli-id {
-                type uint32;
-                mandatory true;
-                description "client id";
-              }
-              container duid {
-                description "Sets the DUID";
-                uses duid;
-              }
-              list cli-iapd {
-                key iaid;
-                description "client IAPD";
-                leaf iaid {
-                  type uint32;
-                  mandatory true;
-                  description "IAID";
-                }
-                leaf-list cli-prefix {
-                  type inet:ipv6-prefix;
-                  description
-                    "client ipv6 prefix";
-                }
-                leaf-list cli-prefix-len {
-                  type uint8;
-                  description
-                    "client prefix length";
-                }
-                leaf pool-id {
-                  type uint32;
-                  mandatory true;
-                  description "pool id";
-                }
-              }
-            }
-          }
-          container hosts {
-            description "hosts level";
-            list host {
-              key cli-id;
-              description "specific host";
-              leaf cli-id {
-                type uint32;
-                mandatory true;
-                description "client id";
-              }
-              container duid {
-                description "Sets the DUID";
-                uses duid;
-              }
-              leaf inherit-option-set {
-                type boolean;
-                mandatory true;
-                description "whether to inherit
-                  configuration
-                  from higher level";
-              }
-              leaf option-set-id {
-                type leafref {
-                  path "/server/option-sets/option-set/id";
-                }
-                description "The ID field of relevant option-set to be
-                  provisioned to clients of this prefix-pool.";
-              }
-              leaf nis-domain-name {
-                type string;
-                description "nis domain name";
-              }
-              leaf nis-plus-domain-name {
-                type string;
-                description "nisp domain name";
-              }
-            }
-          }
     }
-    container relay-opaque-paras {
-      description "This container contains some
-        opaque values in Relay Agent options that
-        need to be configured on the server side
-        only for value match. Such Relay Agent
-        options include Interface-Id option,
-                Remote-Id option and Subscriber-Id option.";
-      list relays {
-        key relay-name;
-        description "relay agents";
-        leaf relay-name {
-          type string;
-          mandatory true;
-          description "relay agent name";
-        }
-        list interface-info {
-          key if-name;
-          description "interface info";
-          leaf if-name {
-            type string;
-            mandatory true;
-            description "interface name";
-          }
-          leaf interface-id {
-            type string;
-            mandatory true;
-            description "interface id";
-          }
-        }
-        list subscribers {
-          key subscriber;
-          description "subscribers";
-          leaf subscriber {
-            type uint32;
-            mandatory true;
-            description "subscriber";
-          }
-          leaf subscriber-id {
-            type string;
-            mandatory true;
-            description "subscriber id";
-          }
-        }
-        list remote-host {
-          key ent-num;
-          description "remote host";
-          leaf ent-num {
-            type uint32;
-            mandatory true;
-            description "enterprise number";
-          }
-          leaf remote-id {
-            type string;
-            mandatory true;
-            description "remote id";
-          }
-        }
-      }
-    }
-    container rsoo-enabled-options {
-      description "rsoo enabled options";
-      list rsoo-enabled-option{
-        key option-code;
-        description "rsoo enabled option";
-        leaf option-code {
-          type uint16;
-          mandatory true;
-          description "option code";
-        }
-        leaf description {
-          type string;
-          mandatory true;
-          description "description of the option";
-        }
-      }
-    }
-    container packet-stats {
-      config "false";
-      description "A container presents
-        the packet statistics related to
-        the DHCPv6 server.";
-      leaf solicit-count {
-        type uint32;
-        mandatory true;
-        description "solicit counter";
-      }
-      leaf request-count {
-        type uint32;
-        mandatory true;
-        description "request counter";
-      }
-      leaf renew-count {
-        type uint32;
-        mandatory true;
-        description "renew counter";
-      }
-      leaf rebind-count {
-        type uint32;
-        mandatory true;
-        description "rebind counter";
-      }
-      leaf decline-count {
-        type uint32;
-        mandatory true;
-        description "decline count";
-      }
-      leaf release-count {
-        type uint32;
-        mandatory true;
-        description "release counter";
-      }
-      leaf info-req-count {
-        type uint32;
-        mandatory true;
-        description "information request
-          counter";
-      }
-      leaf advertise-count {
-        type uint32;
-        mandatory true;
-        description "advertise counter";
-      }
-      leaf confirm-count {
-        type uint32;
-        mandatory true;
-        description "confirm counter";
-      }
-      leaf reply-count {
-        type uint32;
-        mandatory true;
-        description "reply counter";
-      }
-      leaf reconfigure-count {
-        type uint32;
-        mandatory true;
-        description "reconfigure counter";
-      }
-      leaf relay-forward-count {
-        type uint32;
-        mandatory true;
-        description "relay forward counter";
-      }
-      leaf relay-reply-count {
-        type uint32;
-        mandatory true;
-        description "relay reply counter";
-      }
-    }
-  }
-
+    
+    
   /*
    * Notifications
    */

--- a/ietf-dhcpv6-server@2017-11-24.yang
+++ b/ietf-dhcpv6-server@2017-11-24.yang
@@ -12,7 +12,7 @@ module ietf-dhcpv6-server {
   }
   import ietf-dhcpv6-options {
     prefix dhcpv6-options;
-    revision-date "2017-11-24";
+    revision-date "2017-12-04";
   }
 
   organization "DHC WG";
@@ -25,6 +25,12 @@ module ietf-dhcpv6-server {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
+  revision 2017-12-04{
+	  description "First version of the use of 
+		  feature and presence in options";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated server specific
       YANG model.";
@@ -463,154 +469,155 @@ module ietf-dhcpv6-server {
             }
           }
         }
+
+      }
         container prefix-pools {
-          description "If a server supports prefix
-            delegation function, this container will
-            be used to define the delegating router's
-            refix pools.";
-          list prefix-pool {
-            key pool-id;
-            description "Similar to server's
-              address pools, a delegating router
-              can also be configured with multiple
-              prefix pools specified by a list
-              called 'prefix-pool'.";
-            leaf pool-id {
-              type uint32;
-              mandatory true;
-              description "pool id";
-            }
-            leaf prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description "ipv6 prefix";
-            }
-            leaf prefix-length {
-              type uint8;
-              mandatory true;
-              description "prefix length";
-            }
-            leaf renew-time {
-              type yang:timeticks;
-              mandatory true;
-              description "renew time";
-            }
-            leaf rebind-time {
-              type yang:timeticks;
-              mandatory true;
-              description "rebind time";
-            }
-            leaf preferred-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "preferred lifetime for
-                IA";
-            }
-            leaf valid-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "valid lifetime for IA";
-            }
-            leaf utilization-ratio {
-              type threshold;
-              mandatory true;
-              description "utilization ratio";
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "whether to inherit
-                configuration from higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
-              }
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this prefix-pool.";
-            }
-          }
-          list binding-info {
-            key cli-id;
-            config "false";
-            description "A list records a
-              binding information for each
-              DHCPv6 client that has already
-              been allocated IPv6 addresses.";
-            leaf cli-id {
-              type uint32;
-              mandatory true;
-              description "client id";
-            }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            list cli-iapd {
-              key iaid;
-              description "client IAPD";
-              leaf iaid {
-                type uint32;
-                mandatory true;
-                description "IAID";
-              }
-              leaf-list cli-prefix {
-                type inet:ipv6-prefix;
-                description
-                  "client ipv6 prefix";
-              }
-              leaf-list cli-prefix-len {
-                type uint8;
-                description
-                  "client prefix length";
-              }
+            description "If a server supports prefix
+              delegation function, this container will
+              be used to define the delegating router's
+              refix pools.";
+            list prefix-pool {
+              key pool-id;
+              description "Similar to server's
+                address pools, a delegating router
+                can also be configured with multiple
+                prefix pools specified by a list
+                called 'prefix-pool'.";
               leaf pool-id {
                 type uint32;
                 mandatory true;
                 description "pool id";
               }
-            }
-          }
-        }
-        container hosts {
-          description "hosts level";
-          list host {
-            key cli-id;
-            description "specific host";
-            leaf cli-id {
-              type uint32;
-              mandatory true;
-              description "client id";
-            }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "whether to inherit
-                configuration
-                from higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
+              leaf prefix {
+                type inet:ipv6-prefix;
+                mandatory true;
+                description "ipv6 prefix";
               }
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this prefix-pool.";
+              leaf prefix-length {
+                type uint8;
+                mandatory true;
+                description "prefix length";
+              }
+              leaf renew-time {
+                type yang:timeticks;
+                mandatory true;
+                description "renew time";
+              }
+              leaf rebind-time {
+                type yang:timeticks;
+                mandatory true;
+                description "rebind time";
+              }
+              leaf preferred-lifetime {
+                type yang:timeticks;
+                mandatory true;
+                description "preferred lifetime for
+                  IA";
+              }
+              leaf valid-lifetime {
+                type yang:timeticks;
+                mandatory true;
+                description "valid lifetime for IA";
+              }
+              leaf utilization-ratio {
+                type threshold;
+                mandatory true;
+                description "utilization ratio";
+              }
+              leaf inherit-option-set {
+                type boolean;
+                mandatory true;
+                description "whether to inherit
+                  configuration from higher level";
+              }
+              leaf option-set-id {
+                type leafref {
+                  path "/server/option-sets/option-set/id";
+                }
+                description "The ID field of relevant option-set to be
+                  provisioned to clients of this prefix-pool.";
+              }
             }
-            leaf nis-domain-name {
-              type string;
-              description "nis domain name";
-            }
-            leaf nis-plus-domain-name {
-              type string;
-              description "nisp domain name";
+            list binding-info {
+              key cli-id;
+              config "false";
+              description "A list records a
+                binding information for each
+                DHCPv6 client that has already
+                been allocated IPv6 addresses.";
+              leaf cli-id {
+                type uint32;
+                mandatory true;
+                description "client id";
+              }
+              container duid {
+                description "Sets the DUID";
+                uses duid;
+              }
+              list cli-iapd {
+                key iaid;
+                description "client IAPD";
+                leaf iaid {
+                  type uint32;
+                  mandatory true;
+                  description "IAID";
+                }
+                leaf-list cli-prefix {
+                  type inet:ipv6-prefix;
+                  description
+                    "client ipv6 prefix";
+                }
+                leaf-list cli-prefix-len {
+                  type uint8;
+                  description
+                    "client prefix length";
+                }
+                leaf pool-id {
+                  type uint32;
+                  mandatory true;
+                  description "pool id";
+                }
+              }
             }
           }
-        }
-      }
+          container hosts {
+            description "hosts level";
+            list host {
+              key cli-id;
+              description "specific host";
+              leaf cli-id {
+                type uint32;
+                mandatory true;
+                description "client id";
+              }
+              container duid {
+                description "Sets the DUID";
+                uses duid;
+              }
+              leaf inherit-option-set {
+                type boolean;
+                mandatory true;
+                description "whether to inherit
+                  configuration
+                  from higher level";
+              }
+              leaf option-set-id {
+                type leafref {
+                  path "/server/option-sets/option-set/id";
+                }
+                description "The ID field of relevant option-set to be
+                  provisioned to clients of this prefix-pool.";
+              }
+              leaf nis-domain-name {
+                type string;
+                description "nis domain name";
+              }
+              leaf nis-plus-domain-name {
+                type string;
+                description "nisp domain name";
+              }
+            }
+          }
     }
     container relay-opaque-paras {
       description "This container contains some


### PR DESCRIPTION
Hi, here are the changes in this version:
 - used 'presence' to replace 'enable'
 - used 'feature' to represent the support for server/relay/client options
 - made 'option-request-option' optional, because they are not compulsory in 'RELEASE' and 'DECLINE' message initiated by client
However, I am not so sure the use of feature. Should we just need to use 'feature' to indicate whether the option is supported by server/relay/client, or further describe the options one by one so that every option has a corresponding feature? 
