### PR TITLE
Duid & utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# draft-ietf-dhcpv6-yang
+Repo for IETF DHCPV6 YANG draft authors

--- a/ietf-dhcpv6-client@2017-11-24.yang
+++ b/ietf-dhcpv6-client@2017-11-24.yang
@@ -26,13 +26,18 @@ module ietf-dhcpv6-client {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 client.";
 
-  revision 2017-11-24 {
-    description "First version of the separated client specific
-      YANG model.";
-
-    reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+	
+  revision 2017-11-29{
+	  description "First version of the seperation of Configuration
+		  and State trees.";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
   }
-
+  
+  revision 2017-11-24 {
+	    description "First version of the separated client specific
+	      YANG model.";
+  }
+  
   /*
    * Grouping
    */
@@ -54,57 +59,79 @@ module ietf-dhcpv6-client {
   }
 
   grouping duid {
-    description "DHCP Unique Identifier";
-    reference "RFC3315: Section 9";
-    choice duid-type {
-      description "Selects the format for the DUID.";
-      case duid-llt {
-        description "DUID Based on Link-layer Address Plus Time";
-        reference "RFC3315 Section 9.2";
-        leaf duid-llt-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9";
+	    leaf type-code {
+        	type uint16;
+        	description "Type code of this DUID";
+        	default 65535;
         }
-        leaf duid-llt-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-        leaf duid-llt-link-layer-addr {
-          type yang:mac-address;
-          description "Link-layer address as described in RFC2464";
-        }
-      }
-      case duid-en {
-        description "DUID Assigned by Vendor Based on Enterprise Number";
-        reference "RFC3315 Section 9.3";
-        leaf duid-en-enterprise-number {
-          type uint32;
-          description "Vendor's registered Private Enterprise Number as
-            maintained by IANA";
-        }
-        leaf duid-en-identifier {
-          type string;
-          description "Indentifier, unique to the device that is using it";
-        }
-      }
-      case duid-ll {
-        description "DUID Based on Link-layer Address";
-        reference "RFC3315 Section 9.4";
-        leaf duid-ll-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-ll-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-            modulo 2^32.";
-        }
-      }
-    }
-  }
+	    choice duid-type {
+	      description "Selects the format for the DUID.";
+	      default duid-invalid;
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	                        modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
   grouping portset-para {
     description "portset parameters";
     container port-parameter {
@@ -188,117 +215,126 @@ module ietf-dhcpv6-client {
    */
 
  container client {
-    presence "Enables client";
     description "dhcpv6 client portion";
-    container duid {
-      description "Sets the DUID";
-      uses duid;
-    }
-    list client-if {
-      key if-name;
-      description "A client may have several
-        interfaces, it is more reasonable to
-        configure and manage parameters on
-        the interface-level. The list defines
-        specific client interfaces and their
-        data. Different interfaces are distinguished
-        by the key which is a configurable string
-        value.";
-      leaf if-name {
-        type string;
-        mandatory true;
-        description "interface name";
-      }
-      leaf cli-id {
-        type uint32;
-        mandatory true;
-        description "client id";
-      }
-      leaf description {
-        type string;
-        description
-          "description of the client interface";
-      }
-      leaf pd-function {
-        type boolean;
-        mandatory true;
-        description "Whether the client
-          can act as a requesting router
-          to request prefixes using prefix
-          delegation ([RFC3633]).";
-      }
-      leaf rapid-commit {
-        type boolean;
-        mandatory true;
-        description "'1' indicates a client can initiate a Solicit-Reply
-          message exchange by adding a Rapid Commit option in Solicit
-          message. '0' means the client is not allowed to add a Rapid
-          Commit option to request addresses in a two-message exchange
-          pattern.";
-      }
-      container mo-tab {
-        description "The management tab label indicates the operation
-          mode of the DHCPv6 client. 'm'=1 and 'o'=1 indicate the
-          client will use DHCPv6 to obtain all the configuration data.
-          'm'=1 and 'o'=0 are a meaningless combination. 'm'=0 and 'o'=1
-          indicate the client will use stateless DHCPv6 to obtain
-          configuration data apart from addresses/prefixes data.
-          'm'=0 and 'o'=0 represent the client will not use DHCPv6
-          but use SLAAC to achieve configuration.";
-          // if - not sure about the intended use here as it seems
-          // to be redfining what will be received in the PIO. Is
-          // the intention to be whether they PIO options will be
-          // obeyed as received or overridden?
-        leaf m-tab {
-          type boolean;
-          mandatory true;
-          description "m tab";
-        }
-        leaf o-tab {
-          type boolean;
-          mandatory true;
-          description "o tab";
-        }
-      }
-      container client-configured-options {
-        description "client configured options";
-        uses dhcpv6-options:client-option-definitions;
-      }
-
-
-      container if-other-paras {
-        config "false";
-        description "A client can obtain
-          extra configuration data other than
-          address and prefix information through
-          DHCPv6. This container describes such
-          data the client was configured. The
-          potential configuration data may
-          include DNS server addresses, SIP
-          server domain names, etc.";
-        uses dhcpv6-options:server-option-definitions;
-
-        container supported-options {
-          // if - Unclear on what this container is used for. Maybe
-          // putting options as 'features' could replace this.
-          description "supported options";
-          list supported-option {
-            key option-code;
-            description "supported option";
-            leaf option-code {
-              type uint16;
+    
+    container client-config{
+    	description "configuration tree of client";
+    	
+        container duid {
+            description "Sets the DUID";
+            uses duid;
+          }
+          list client-if {
+            key if-name;
+            description "A client may have several
+              interfaces, it is more reasonable to
+              configure and manage parameters on
+              the interface-level. The list defines
+              specific client interfaces and their
+              data. Different interfaces are distinguished
+              by the key which is a configurable string
+              value.";
+            leaf if-name {
+              type string;
               mandatory true;
-              description "option code";
+              description "interface name";
+            }
+            leaf cli-id {
+              type uint32;
+              mandatory true;
+              description "client id";
             }
             leaf description {
               type string;
-              mandatory true;
               description
-                "description of supported option";
+                "description of the client interface";
+            }
+            leaf pd-function {
+              type boolean;
+              mandatory true;
+              description "Whether the client
+                can act as a requesting router
+                to request prefixes using prefix
+                delegation ([RFC3633]).";
+            }
+            leaf rapid-commit {
+              type boolean;
+              mandatory true;
+              description "'1' indicates a client can initiate a Solicit-Reply
+                message exchange by adding a Rapid Commit option in Solicit
+                message. '0' means the client is not allowed to add a Rapid
+                Commit option to request addresses in a two-message exchange
+                pattern.";
+            }
+            container mo-tab {
+              description "The management tab label indicates the operation
+                mode of the DHCPv6 client. 'm'=1 and 'o'=1 indicate the
+                client will use DHCPv6 to obtain all the configuration data.
+                'm'=1 and 'o'=0 are a meaningless combination. 'm'=0 and 'o'=1
+                indicate the client will use stateless DHCPv6 to obtain
+                configuration data apart from addresses/prefixes data.
+                'm'=0 and 'o'=0 represent the client will not use DHCPv6
+                but use SLAAC to achieve configuration.";
+                // if - not sure about the intended use here as it seems
+                // to be redfining what will be received in the PIO. Is
+                // the intention to be whether they PIO options will be
+                // obeyed as received or overridden?
+              leaf m-tab {
+                type boolean;
+                mandatory true;
+                description "m tab";
+              }
+              leaf o-tab {
+                type boolean;
+                mandatory true;
+                description "o tab";
+              }
+            }
+            container client-configured-options {
+              description "client configured options";
+              uses dhcpv6-options:client-option-definitions;
+            }
+    }
+    
+    
+    }
+    
+    container client-state{
+    	description "state tree of client";
+    	
+    	config "false";
+        container if-other-paras {
+            description "A client can obtain
+              extra configuration data other than
+              address and prefix information through
+              DHCPv6. This container describes such
+              data the client was configured. The
+              potential configuration data may
+              include DNS server addresses, SIP
+              server domain names, etc.";
+            uses dhcpv6-options:server-option-definitions;
+
+            container supported-options {
+              // if - Unclear on what this container is used for. Maybe
+              // putting options as 'features' could replace this.
+              description "supported options";
+              list supported-option {
+                key option-code;
+                description "supported option";
+                leaf option-code {
+                  type uint16;
+                  mandatory true;
+                  description "option code";
+                }
+                leaf description {
+                  type string;
+                  mandatory true;
+                  description
+                    "description of supported option";
+                }
+              }
             }
           }
-        }
-      }
     }
   }
 

--- a/ietf-dhcpv6-options@2017-11-24.yang
+++ b/ietf-dhcpv6-options@2017-11-24.yang
@@ -31,7 +31,187 @@ module ietf-dhcpv6-options {
   /*
    * Features
    */
-
+    
+  	// features for server options
+  	feature server-id-op {
+  		description "Support for Server ID option";
+  	}
+	feature server-unicast-op {
+		description "Support for Server Unicast option";
+	}
+	feature sip-server-domain-name-list-op {
+		description "Support for SIP Server Domain Name List option";
+	}
+	feature sip-server-address-list-op {
+		description "Support for SIP Server Address List option";
+	}
+	feature dns-config-op {
+		description "Support for DNS Recursive Name Server option";
+	}
+	feature domain-searchlist-op {
+		description "Support for Domain Search List Option";
+	}
+	feature nis-config-op {
+		description "Support for Network Information Service (NIS)
+			Servers option";
+	}
+	feature nis-plus-config-op {
+		description "Support for Network Information Service V2 (NIS+) 
+			Servers option";
+	}
+  	feature nis-domain-name-op {
+  		description "Support for Network Information Service (NIS)
+  			Domain Name option";
+  	}
+  	feature nis-plus-domain-name-op {
+  		description "Support for Network Information Service V2 (NIS+)
+  			Server option";
+  	}
+  	feature sntp-server-op {
+  		description "Support for Simple Network Protocol Configuration 
+  			(SNTP) Servers option";
+  	}
+  	feature info-refresh-time-op {
+  		description "Support for Information Refresh Time option";
+  	}
+  	feature client-fqdn-op {
+  		description "Support for Client FQDN option";
+  	}
+  	feature posix-timezone-op {
+  		description "Support for New POIX Timezone option";
+  	}
+  	feature tzdb-timezone-op {
+  		description "Support for New TZDB Timezone option";
+  	}
+  	feature ntp-server-op {
+  		description "Support for Network Time Protocol (NTP) 
+  			Server option";
+  	}
+  	feature boot-file-url-op {
+  		description "Support for Boot File URL option";
+  	}
+  	feature boot-file-param-op {
+  		description "Support for Boot File Parameters option";
+  	}
+  	feature aftr-name-op {
+  		description "Support for Address Family Transition
+  			Router (AFTR) option";
+  	}
+  	feature kbr-default-name-op {
+  		description "Support for Kerberos Default Name 
+  			Option";
+  	}
+  	feature kbr-kdc-op {
+  		description "Support for Kerberos KDC option";
+  	}
+  	feature sol-max-rt-op {
+  		description "Support for SOL_MAX_RT option";
+  	}
+  	feature inf-max-rt-op {
+  		description "Support for INF_MAX_RT option";
+  	}
+  	feature addr-selection-op {
+  		description "Support for Address Selection opiton";
+  	}
+  	feature pcp-server-op {
+  		description "Support for Port Control Protocol (PCP)
+  			option";
+  	}
+  	feature s46-rule-op {
+  		description "Support for S46 Rule option";
+  	}
+  	feature s46-br-op {
+  		description "Support for S46 Border Relay (BR) option";
+  	}
+  	feature s46-dmr-op {
+  		description "Support for S46 Default Mapping Rule 
+  			(DMR) option";
+  	}
+  	feature s46-v4-v6-binding-op {
+  		description "Support for S46 IPv4/IPv6 Address
+  			Bind option";
+  	}
+  	
+  	// features for relay-supplied options
+  	feature erp-local-domain-name-op {
+  		description "Support for ERP Local Domain
+  			Name option";
+  	}
+  	
+  	// features for client options
+  	feature client-id-op {
+  		description "Support for Client ID option";
+  	}
+  	feature option-request-op {
+  		description "Support for Option Request option";
+  	}
+  	feature rapid-commit-op {
+  		description "Support for Rapid Commit option";
+  	}
+  	feature user-class-op {
+  		description "Support for User Class option";
+  	}
+  	feature vendor-class-op {
+  		description "Support for Vendor Class option";
+  	}
+  	feature client-arch-type-op {
+  		description "Support for Client System Architecture
+  			Type option";
+  	}
+  	feature client-network-interface-identifier-op {
+  		description "Support for Client Network Interface
+  			Identifier option";
+  	}
+  	feature kbr-principal-name-op {
+  		description "Support for Kerberos Principal
+  			Name option";
+  	}
+  	feature kbr-realm-name-op {
+  		description "Support Kerberos Realm Name option";
+  	}
+  	feature client-link-layer-addr-op {
+  		description "Support for Client Link-Layer Address
+  			Option";
+  	}
+  	
+  	// features for custom options
+  	feature operator-op-ipv6-address {
+  		description "Support for Option with IPv6 Addresses";
+  	}
+  	feature operator-op-single-flag {
+  		description "Support for Option with Single Flag";
+  	}
+  	feature operator-op-ipv6-prefix {
+  		description "Support for Option with IPv6 Prefix";
+  	}
+	feature operator-op-int32 {
+		description "Support for Opion with 32-bit
+			Integer Value";
+	}
+	feature operator-op-int16 {
+		description "Support for Opion with 16-bit
+			Integer Value";
+	}
+	feature operator-op-int8 {
+		description "Support for Opion with 8-bit
+			Integer Value";
+	}
+	feature operator-op-uri {
+		description "Support for Opion with URI";
+	}
+	feature operator-op-textstring {
+		description "Support for Opion with Text
+			String";
+	}
+	feature operator-op-var-data {
+		description "Support for Opion with 
+			Variable-Length Data";
+	}
+	feature operator-op-dns-wire {
+		description "Support for Opion with DNS Wire
+			Format Domain Name List";
+	}
+	
   /*
    * Groupings
    */
@@ -58,10 +238,98 @@ module ietf-dhcpv6-options {
    }
   }
 
+  grouping duid {
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9";
+	    leaf type-code {
+        	type uint16;
+        	description "Type code of this DUID";
+        	default 65535;
+        }
+	    choice duid-type {
+	      description "Selects the format for the DUID.";
+	      default duid-invalid;
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	                        modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
+  
   grouping server-option-definitions {
     description "Contains definitions for options configured on the
       DHCPv6 server which will be supplied to clients.";
+    container server-id-option {
+    	if-feature server-id-op;
+    	presence "Enable this option";
+    	description "OPTION_SERVERID (2) Server Identifier";
+        reference "RFC3315: Dynamic Host Configuration Protocol
+            for IPv6 (DHCPv6)";
+		container duid {
+			description "The DUID for the server";
+			uses duid;
+		}
+    }
     container server-unicast-option {
+      if-feature server-unicast-op;
+      presence "Enable this option";
       description "OPTION_UNICAST (12) Server Unicast Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -69,56 +337,49 @@ module ietf-dhcpv6-options {
         type inet:ipv6-address;
       }
     }
-    container sip-server-option {
-      description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List
-      and OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
-      /* if - Note - this container is currently modelling two options
-       (21 & 22). It would allow the config of a mixed list of domain
-       names and addresses in a way that doesn't follow the
-       RFC. Needs to be broken into SIP Domain list and SIP Address
-       list containers */
-      reference "RFC3319: Dynamic Host Configuration Protocol
-        (DHCPv6) Options for Session Initiation Protocol (SIP)
-        Servers";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "Indicate whether this option will be included in
-          the option set";
-      }
-      list sip-server {
-        key sip-serv-id;
-        description "sip server info";
-        leaf sip-serv-id {
-          type uint8;
-          mandatory true;
-          description "sip server id";
-        }
-        leaf sip-serv-domain-name {
-          type string;
-          mandatory true;
-          description "sip server domain
-            name";
-        }
-        leaf sip-serv-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "sip server addr";
-        }
-      }
+    container sip-server-domain-name-list-option {
+        if-feature sip-server-domain-name-list-op;
+        presence "Enable this option";
+        description "OPTION_SIP_SERVER_D (21) SIP Servers Domain Name List";
+        reference "RFC3319: Dynamic Host Configuration Protocol
+          (DHCPv6) Options for Session Initiation Protocol (SIP)
+          Servers";
+          leaf sip-serv-domain-name {
+            type string;
+            mandatory true;
+            description "sip server domain
+              name";
+          }
     }
+    container sip-server-address-list-option {
+        if-feature sip-server-address-list-op;
+        presence "Enable this option";
+        description "OPTION_SIP_SERVER_A (22) SIP Servers IPv6 Address List";
+        reference "RFC3319: Dynamic Host Configuration Protocol
+          (DHCPv6) Options for Session Initiation Protocol (SIP)
+          Servers";
+        list sip-server {
+          key sip-serv-id;
+          description "sip server info";
+          leaf sip-serv-id {
+            type uint8;
+            mandatory true;
+            description "sip server id";
+          }
+          leaf sip-serv-addr {
+            type inet:ipv6-address;
+            mandatory true;
+            description "sip server addr";
+          }
+        }
+    }   
     container dns-config-option {
+      if-feature dns-config-op;
+      presence "Enable this option";
       description "OPTION_DNS_SERVERS (23) DNS recursive Name
         Server option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list dns-server {
         key dns-serv-id;
         description "dns server info";
@@ -135,16 +396,11 @@ module ietf-dhcpv6-options {
       }
     }
     container domain-searchlist-option {
+      if-feature domain-searchlist-op;
+      presence "Enable this option";
       description "OPTION_DOMAIN_LIST (24) Domain Search List Option";
       reference "RFC3646: DNS Configuration options for Dynamic
         Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list domain-searchlist {
         key domain-searchlist-id;
         description "dns server info";
@@ -161,17 +417,12 @@ module ietf-dhcpv6-options {
       }
     }
     container nis-config-option {
+      if-feature nis-config-op;
+      presence "Enable this option";
       description "OPTION_NIS_SERVERS (27) Network Information Service (NIS)
         Servers Option.";
-      reference "RFC3989: Network Information Service (NIS) Configuration
+      reference "RFC3898: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list nis-server {
         key nis-serv-id;
         description "nis server info";
@@ -188,17 +439,12 @@ module ietf-dhcpv6-options {
       }
     }
     container nis-plus-config-option {
+      if-feature nis-plus-config-op;
+      presence "Enable this option";
       description "OPTION_NISP_SERVERS (28): Network Information Service V2
         (NIS+) Servers Option.";
       reference "RFC3989: Network Information Service (NIS) Configuration
         Options for Dynamic Host Configuration Protocol for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list nis-plus-server {
         key nis-plus-serv-id;
         description "NIS+ server information.";
@@ -214,19 +460,14 @@ module ietf-dhcpv6-options {
         }
       }
     }
-    container nis-domain-name {
+    container nis-domain-name-option {
+      if-feature nis-domain-name-op;
+      presence "Enable this option";
       description "OPTION_NIS_DOMAIN_NAME (29) Network Information
         Service (NIS) Domain Name Option";
       reference "RFC3989: Network Information Service (NIS)
         Configuration Options for Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       leaf nis-domain-name {
         type string;
         description "The Network Information Service (NIS) Domain Name
@@ -234,18 +475,28 @@ module ietf-dhcpv6-options {
         info to the client.";
       }
     }
+    container nis-plus-domain-name-option {
+        if-feature nis-plus-domain-name-op;
+        presence "Enable this option";
+        description "OPTION_NISP_DOMAIN_NAME (30) Network Information 
+          Service V2 (NIS+) Domain Name Option";
+        reference "RFC3989: Network Information Service (NIS)
+          Configuration Options for Dynamic Host Configuration Protocol
+          for IPv6 (DHCPv6)";
+        leaf nis-plus-domain-name {
+          type string;
+          description "The Network Information Service V2 (NIS+) Domain Name
+          option is used by the server to convey client's NIS+ Domain Name
+          info to the client.";
+        }
+      }
     container sntp-server-option {
+      if-feature sntp-server-op;
+      presence "Enable this option";
       description "OPTION_SNTP_SERVERS (31) Simple Network Time Protocol
         (SNTP) Servers Option";
       reference "RFC4075: Simple Network Time Protocol (SNTP) Configuration
         Option for DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list sntp-server {
         key sntp-serv-id;
         description "sntp server info";
@@ -262,33 +513,24 @@ module ietf-dhcpv6-options {
       }
     }
     container info-refresh-time-option {
+      if-feature info-refresh-time-op;
+      presence "Enable this option";	
       description "OPTION_INFORMATION_REFRESH_TIME (32) Information Refresh
         Time option.";
       reference "RFC4242: Information Refresh Time Option for Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-         option will be included in the
-         option set";
-      }
       leaf info-refresh-time {
         type yang:timeticks;
         mandatory true;
         description "The refresh time.";
       }
     }
-    container cli-fqdn-option {
+    container client-fqdn-option {
+      if-feature client-fqdn-op;
+      presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) DHCPv6 Client FQDN Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol for IPv6
         (DHCPv6) Client Fully Qualified Domain Name (FQDN) Option";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }
       leaf server-initiate-update {
         type boolean;
         mandatory true;
@@ -306,47 +548,38 @@ module ietf-dhcpv6-options {
       }
     }
     container posix-timezone-option {
+      if-feature posix-timezone-op;
+      presence "Enable this option";
       description "OPTION_NEW_POSIX_TIMEZONE (41) Posix Timezone option";
-      reference "RFC4822: Timezone Options for DHCP";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }
+      reference "RFC4833: Timezone Options for DHCP";
       leaf tz-posix {
         type string;
         mandatory true;
         description "TZ Posix IEEE 1003.1 String";
       }
     }
-    container posix-timezone-option-db-option {
+    container tzdb-timezone-option {
+      if-feature tzdb-timezone-op;
+      presence "Enable this option";
       description "OPTION_NEW_TZDB_TIMEZONE (42) Timezone Database option";
       reference "RFC4822: Timezone Options for DHCP";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }
       leaf tz-database {
         type string;
         mandatory true;
         description "Reference to the TZ Database";
       }
-    }
+    }  
     container ntp-server-option {
       //This option looks like it needs work to correctly model the
       //option as defined in the RFC.
+    	
+      // Zihao - Re-modelled so it only contains one 
+    	// time source suboption
+      if-feature ntp-server-op;
+      presence "Enable this option";
       description "OPTION_NTP_SERVER (56) NTP Server Option for DHCPv6";
       reference "RFC5908: Network Time Protocol (NTP) Server Option for
       DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-          option set";
-      }
       list ntp-server {
         key ntp-serv-id;
         description "ntp server info";
@@ -355,158 +588,153 @@ module ietf-dhcpv6-options {
           mandatory true;
           description "ntp server id";
         }
-        leaf ntp-serv-addr-suboption {
-          type inet:ipv6-address;
-          mandatory true;
-          description "ntp server addr";
-        }
-        leaf ntp-serv-mul-addr-suboption {
-          type inet:ipv6-address;
-          mandatory true;
-          description "ntp server multicast addr";
-        }
-        leaf ntp-serv-fqdn-suboption {
-          type string;
-          mandatory true;
-          description "ntp server fqdn";
+        choice ntp-time-source-suboption {
+        	description "Select a NTP time source suboption.";
+        	case server-address {
+	    	leaf-list ntp-serv-addr-suboption {
+	    	          type inet:ipv6-address;
+	    	          description "ntp server addr";
+	    	        }
+        	}
+        	case server-multicast-address {
+        		leaf-list ntp-serv-mul-addr-suboption {
+        	          type inet:ipv6-address;
+        	          description "ntp server multicast addr";
+        	        }
+        	}
+        	case server-fqdn {
+        		leaf-list ntp-serv-fqdn-suboption {
+                    type string;
+                    description "ntp server fqdn";
+                  }
+        	}       	
         }
       }
-    }
-    container network-boot-option {
-      description "OPT_BOOTFILE_URL (59) and OPT_BOOTFILE_PARAM (60)";
-      reference "RFC5970: DHCPv6 Options for Network Boot";
-      // if - Looks like 2 options combined that need to be split out
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
-      list boot-file {
-        key boot-file-id;
-        description "boot file info";
-        leaf boot-file-id {
-          type uint8;
-          mandatory true;
-          description "boot file id";
-        }
-        leaf-list suitable-arch-type {
-          type uint16;
-          description "architecture type";
-        }
-        leaf-list suitable-net-if {
-          type uint32;
-          description "network interface";
-        }
-        leaf boot-file-url {
-          type string;
-          mandatory true;
-          description "url for boot file";
-        }
+    }    
+	container boot-file-url-option {
+		if-feature boot-file-url-op;
+		presence "Enable this option";
+		description "OPT_BOOTFILE_URL (59) Boot File URL option";
+		reference "RFC5970: DHCPv6 Options for Network Boot";		
+		list boot-file {
+			key boot-file-id;
+			description "boot file info";
+			leaf boot-file-id {
+				type uint8;
+				mandatory true;
+				description "boot file id";
+			}
+	        leaf-list suitable-arch-type {
+	            type uint16;
+	            description "architecture type";
+	          }
+          	leaf-list suitable-net-if {
+            	type uint32;
+            	description "network interface";
+          	}
+			leaf boot-file-url {
+				type string;
+				mandatory true;
+				description "url for boot file";
+			}
+		}
+	}	
+	container boot-file-param-option {
+		if-feature boot-file-param-op;
+		presence "Enable this option";
+		description "OPT_BOOTFiLE_PARAM (60) Boot File Parameters Option";
+		reference "RFC5970: DHCPv6 Options for Network Boot";
         list boot-file-paras {
-          key para-id;
-          description "boot file parameters";
-          leaf para-id {
-            type uint8;
-            mandatory true;
-            description "parameter id";
+            key para-id;
+            description "boot file parameters";
+            leaf para-id {
+              type uint8;
+              mandatory true;
+              description "parameter id";
+            }
+            leaf parameter {
+              type string;
+              mandatory true;
+              description "parameter
+                value";
+            }
+            
           }
-          leaf parameter {
-            type string;
-            mandatory true;
-            description "parameter
-              value";
-          }
-        }
-      }
-    }
+	}   
     container aftr-name-option {
+      if-feature aftr-name-op;
+      presence "Enable this option";
       description "OPTION_AFTR_NAME (64) AFTR-Name DHCPv6 Option";
       reference "RFC6334: Dynamic Host Configuration Protocol for IPv6
       (DHCPv6) Option for Dual-Stack Lite";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-        option set";
-      }
       leaf tunnel-endpoint-name {
         type string;
         mandatory true;
         description "aftr name";
       }
+    }    
+    container kbr-default-name-option {
+    	if-feature kbr-default-name-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_DEFAULT_REALM_NAME (77) Kerberos Default Realm Name Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+        leaf default-realm-name {
+            type string;
+            mandatory true;
+            description "default realm name";
+          }
     }
-    container kerberos-option {
-      //This needs re-working and possibly splitting into several option
-      //containers to follow the RFC.
-      description "OPTION_KRB_KDC (78) Kerberos KDB Option, OPTION_KRB_REALM_NAME (76)
-        Kerberos Realm Name Option and OPTION_KRB_DEFAULT_REALM_NAME (77)
-        Kerberos Default Realm Name Option";
-      reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
-      leaf default-realm-name {
-        type string;
-        mandatory true;
-        description "default realm name";
-      }
-      list kdc-info {
-        key kdc-id;
-        description "kdc info";
-        leaf kdc-id {
-          type uint8;
-          mandatory true;
-          description "kdc id";
-        }
-        leaf priority {
-          type uint16;
-          mandatory true;
-          description "priority";
-        }
-        leaf weight {
-          type uint16;
-          mandatory true;
-          description "weight";
-        }
-        leaf transport-type {
-          type uint8;
-          mandatory true;
-          description "transport type";
-        }
-        leaf port-number {
-          type uint16;
-          mandatory true;
-          description "port number";
-        }
-        leaf kdc-ipv6-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "kdc ipv6 addr";
-        }
-        leaf realm-name {
-          type string;
-          mandatory true;
-          description "realm name";
-        }
-      }
-    }
+    container kbr-kdc-option {
+    	if-feature kbr-kdc-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_KDC (78) Kerberos KDB Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+        list kdc-info {
+            key kdc-id;
+            description "kdc info";
+            leaf kdc-id {
+              type uint8;
+              mandatory true;
+              description "kdc id";
+            }
+            leaf priority {
+              type uint16;
+              mandatory true;
+              description "priority";
+            }
+            leaf weight {
+              type uint16;
+              mandatory true;
+              description "weight";
+            }
+            leaf transport-type {
+              type uint8;
+              mandatory true;
+              description "transport type";
+            }
+            leaf port-number {
+              type uint16;
+              mandatory true;
+              description "port number";
+            }
+            leaf kdc-ipv6-addr {
+              type inet:ipv6-address;
+              mandatory true;
+              description "kdc ipv6 addr";
+            }
+            leaf realm-name {
+              type string;
+              mandatory true;
+              description "realm name";
+            }
+          }
+    }    
     container sol-max-rt-option {
+      if-feature sol-max-rt-op;
+      presence "Enable this option";
       description "OPTION_SOL_MAX_RT (82) sol max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-        }
         leaf sol-max-rt-value {
           type yang:timeticks;
           mandatory true;
@@ -514,34 +742,26 @@ module ietf-dhcpv6-options {
         }
     }
     container inf-max-rt-option {
+      if-feature inf-max-rt-op;
+      presence "Enable this option";
       description "OPTION_INF_MAX_RT (83) inf max rt option";
       reference "RFC7083: Modification to Default Values of
         SOL_MAX_RT and INF_MAX_RT";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       leaf inf-max-rt-value {
         type yang:timeticks;
         mandatory true;
         description "inf max rt value";
       }
-    }
+    }       
     container addr-selection-option {
+      if-feature addr-selection-op;
+      presence "Enable this option";
       description "OPTION_ADDRSEL (84) and OPTION_ADDRSEL_TABLE (85)";
       reference "RFC7078: Distributing Address Selection Policy Using
       DHCPv6";
       // if - Needs checking to see if this matches the RFC - there
       // are two options here.
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included in the
-                  option set";
-        }
+      // Zihao - I think this matches RFC7078
       leaf a-bit-set {
         type boolean;
         mandatory true;
@@ -583,16 +803,12 @@ module ietf-dhcpv6-options {
       }
     }
     container pcp-server-option {
+      if-feature pcp-server-op;
+      presence "Enable this option";
       description "OPTION_V6_PCP_SERVER (86)
         pcp server option";
       reference "RFC7291: DHCP Options for the Port Control
         Protocol (PCP)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      }
       list pcp-server {
         key pcp-serv-id;
         description "pcp server info";
@@ -609,15 +825,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-rule-option {
+      if-feature s46-rule-op;
+      presence "Enable this option";
       description "OPTION_S46_RULE (89) S46 rule option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      }
       list s46-rule {
         key rule-id;
         description "s46 rule";
@@ -662,15 +874,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-br-option {
+      if-feature s46-br-op;
+      presence "Enable this option";
       description "OPTION_S46_BR (90) S46 BR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be included
-          in the option set";
-      }
       list br {
         key br-id;
         description "br info";
@@ -687,16 +895,11 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-dmr-option {
+      if-feature s46-dmr-op;
+      presence "Enable this option";
       description "OPTION_S46_DMR (91) S46 DMR Option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list dmr {
         key dmr-id;
         description "dmr info";
@@ -718,17 +921,12 @@ module ietf-dhcpv6-options {
       }
     }
     container s46-v4-v6-binding-option {
+      if-feature s46-v4-v6-binding-op;
+      presence "Enable this option";
       description "OPTION_S46_V4V6BIND (92) S46 IPv4/IPv6 Address
         Binding option";
       reference "RFC7598: DHCPv6 Options for Configuration of
         Softwire Address and Port-Mapped Clients";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list ce {
         key ce-id;
         description "ce info";
@@ -761,20 +959,15 @@ module ietf-dhcpv6-options {
 
   grouping relay-supplied-option-definitions {
     // if - The structure here needs to be checked and probably reworked.
-    description "Relay supplied DHCP Options";
+    description "OPTION_RSOO (66) Relay-Supplied Options option";
     reference "RFC6422: Relay-Supplied DHCP Options";
     container erp-local-domain-name-option {
+      if-feature erp-local-domain-name-op;
+      presence "Enable this option";
       description "OPTION_ERP_LOCAL_DOMAIN_NAME (65) DHCPv6 ERP Local
         Domain Name Option";
       reference "RFC6440: The EAP Re-authentication Protocol (ERP)
         Local Domain Name DHCPv6 Option";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether
-          this option is included in the
-          rsoo set";
-      }
       list erp-for-client {
         key cli-id;
         description "erp for client";
@@ -829,7 +1022,20 @@ module ietf-dhcpv6-options {
         description "the option value";
       }
     }
+    container client-id-option {
+    	if-feature client-id-op;
+    	presence "Enable this option";
+    	description "OPTION_SERVERID (1) Client Identifier";
+        reference "RFC3315: Dynamic Host Configuration Protocol
+            for IPv6 (DHCPv6)";
+		container duid {
+			description "The DUID for the client";
+			uses duid;
+		}
+    }
     container option-request-option {
+      if-feature option-request-op;
+      presence "Enable this option";
       description "OPTION_ORO (6) Option Request Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
@@ -850,27 +1056,22 @@ module ietf-dhcpv6-options {
       }
     }
     container rapid-commit-option {
+      if-feature rapid-commit-op;
+      presence "Enable this option";
       description "OPTION_RAPID_COMMIT (14)";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      leaf enable-rapid-commit {
-        type boolean;
-      }
       // if - This fuction is also being covered by
       // /client/client-if/rapid-commit switch. Is it better
-      // defined there or as an option?
+      // defined there or as an option?      
+      // Zihao - I think it is better defined in server/client model
     }
     container user-class-option {
+      if-feature user-class-op;
+      presence "Enable this option";
       description "OPTION_USER_CLASS (15) User Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }
       list user-class {
         key user-class-id;
         description "user class";
@@ -890,22 +1091,17 @@ module ietf-dhcpv6-options {
       }
     }
     container vendor-class-option {
+      if-feature vendor-class-op;
+      presence "Enable this option";
       description "OPTION_VENDOR_CLASS (16) Vendor Class Option";
       reference "RFC3315: Dynamic Host Configuration Protocol
       for IPv6 (DHCPv6)";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }
       leaf enterprise-number {
         type uint32;
         mandatory true;
         description "enterprise number";
       }
-      leaf-list vendor-class-data {
+  /*    leaf-list vendor-class-data {
         type string;
         description "The vendor-class-data is composed of a series
           of separate items, each of which describes some
@@ -915,22 +1111,37 @@ module ietf-dhcpv6-options {
           the amount of memory installed on the client.";
           // if - It may be better to model this as a leaf-list
           // so the list contents can be indexed.
+      } */
+      
+      list vendor-class {
+    	  key vendor-class-id;
+    	  description "vendor class";
+          leaf vendor-class-id {
+              type uint8;
+              mandatory true;
+              description "vendor class id";
+            }
+          leaf vendor-class-data {
+        	  type string;
+        	  mandatory true;
+        	  description "The vendor-class-data is composed of a series
+                  of separate items, each of which describes some
+                  characteristic of the client's hardware configuration.
+                  Examples of vendor-class-data instances might include the
+                  version of the operating system the client is running or
+                  the amount of memory installed on the client.";
+          }
       }
-    }
+    }   
     container client-fqdn-option {
+      if-feature client-fqdn-op;
+      presence "Enable this option";
       description "OPTION_CLIENT_FQDN (39) The Dynamic Host
         Configuration Protocol for IPv6 (DHCPv6) Client Fully
         Qualified Domain Name (FQDN) Option";
       reference "RFC4704: The Dynamic Host Configuration Protocol
         for IPv6 (DHCPv6) Client Fully Qualified Domain Name (FQDN)
         Option";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }
       leaf fqdn {
         type string;
         mandatory true;
@@ -948,16 +1159,11 @@ module ietf-dhcpv6-options {
       }
     }
     container client-arch-type-option {
+      if-feature client-arch-type-op;
+      presence "Enable this option";
       description "OPTION_CLIENT_ARCH_TYPE (61) Client System
         Architecture Type Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }
       list architecture-types {
         key type-id;
         description "architecture types";
@@ -974,17 +1180,11 @@ module ietf-dhcpv6-options {
       }
     }
     container client-network-interface-identifier-option {
-      description
-        "OPTION_NII (62) Client Network Interface Identifier
-        Option";
+      if-feature client-network-interface-identifier-op;
+      presence "Enable this option";
+      description "OPTION_NII (62) Client Network Interface 
+    	  Identifier Option";
       reference "RFC5970: DHCPv6 Options for Network Boot";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
-      }
       leaf type {
         type uint8;
         mandatory true;
@@ -1001,35 +1201,53 @@ module ietf-dhcpv6-options {
         description "minor";
       }
     }
-    container krb-principal-name-option {
+    container kbr-principal-name-option {
+      if-feature kbr-principal-name-op;
+      presence "Enable this option";
       description "OPTION_KRB_PRINCIPAL_NAME (75) Kerberos
         Principal Name Option";
       reference "RFC6784: Kerberos Options for DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be configured at the
-          client";
+      list principle-name {
+    	  key principle-name-id;
+    	  description "principle name";
+    	  leaf principle-name-id {
+    		  type uint8;
+    		  mandatory true;
+    		  description "principle name id";
+    	  }
+    	  leaf name-type {
+    		  type int32;
+    		  mandatory true;
+    		  description "This field specifies the type of name that follows.";
+    	  }
+    	  leaf name-string {
+    		  type string;
+    		  mandatory true;
+    		  description "This field encodes a sequence of components that form
+    			  a name, each component encoded as a KerberoString";
+    	  }
       }
-      leaf principal-name {
-        type string;
-        mandatory true;
-        description "principal name";
         // if - this can probably be typed according to RFC4120 5.2.2
-      }
+     	// Zihao - Done
+      }   
+    container kbr-realm-name-option {
+    	if-feature kbr-realm-name-op;
+    	presence "Enable this option";
+    	description "OPTION_KRB_REALM_NAME (76) Kerberos Realm Name Option";
+    	reference "RFC6784: Kerberos Options for DHCPv6";
+    	leaf realm-name {
+    		type string;
+    		mandatory true;
+    		description "realm name";
+    	}
     }
     container client-link-layer-addr-option {
+      if-feature client-link-layer-addr-op;
+      presence "Enable this option";
       description "OPTION_CLIENT_LINKLAYER_ADDR (79) DHCPv6 Client
         Link-Layer Address Option";
       reference "RFC6939: Client Link-Layer Address Option in
         DHCPv6";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this option will be configured
-          at the client";
-      }
       leaf link-layer-type {
         type uint16;
         mandatory true;
@@ -1043,19 +1261,16 @@ module ietf-dhcpv6-options {
         description "Client link-layer address";
       }
     }
-  }
+    }
+
+  
 
   grouping custom-option-definitions {
     container operator-option-ipv6-address {
+      if-feature operator-op-ipv6-address;
+      presence "Enable this option";
       description "operator ipv6 address option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list operator-ipv6-addr {
         key operator-ipv6-addr-id;
         description "operator ipv6 address info";
@@ -1072,16 +1287,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-single-flag {
+      if-feature operator-op-single-flag;
+      presence "Enable this option";
       description "operator single flag";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list flag {
         key flag-id;
         description "operator single flag info";
@@ -1098,16 +1308,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-ipv6-prefix {
+      if-feature operator-op-ipv6-prefix;
+      presence "Enable this option";
       description "operator ipv6 prefix option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list operator-ipv6-prefix{
         key operator-ipv6-prefix-id;
         description "operator ipv6 prefix info";
@@ -1129,16 +1334,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int32 {
+      if-feature operator-op-int32;
+      presence "Enable this option";
       description "operator integer 32 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list int32val{
         key int32val-id;
         description "operator integer 32 info";
@@ -1155,16 +1355,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int16 {
+      if-feature operator-op-int16;
+      presence "Enable this option";
       description "operator integer 16 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list int16val{
         key int16val-id;
         description "operator integer 16 info";
@@ -1181,16 +1376,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-int8 {
+      if-feature operator-op-int8;
+      presence "Enable this option";
       description "operator integer 8 option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list int8val{
         key int8val-id;
         description "operator integer 8 info";
@@ -1207,16 +1397,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-uri {
+      if-feature operator-op-uri;
+      presence "Enable this option";
       description "operator uri option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list uri{
         key uri-id;
         description "operator uri info";
@@ -1233,15 +1418,10 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-textstring {
+      if-feature operator-op-textstring;
+      presence "Enable this option";
       description "operator itext string option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list textstring{
         key textstring-id;
         description "operator text string info";
@@ -1258,15 +1438,10 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-var-data {
+      if-feature operator-op-var-data;
+      presence "Enable this option";
       description "operator variable length data option";
       reference "RFC7227: Guidelines for Creating New DHCPv6 Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list int32val{
         key var-data-id;
         description "operator ivariable length data info";
@@ -1283,16 +1458,11 @@ module ietf-dhcpv6-options {
       }
     }
     container operator-option-dns-wire {
+      if-feature operator-op-dns-wire;
+      presence "Enable this option";
       description "operator dns wire format domain name list option";
       reference "RFC7227: Guidelines for Creating New DHCPv6
         Options";
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description "indicate whether this
-          option will be included in the
-          option set";
-      }
       list operator-option-dns-wire{
         key operator-option-dns-wire-id;
         description "operator dns wire format info";

--- a/ietf-dhcpv6-relay@2017-11-24.yang
+++ b/ietf-dhcpv6-relay@2017-11-24.yang
@@ -22,6 +22,12 @@ module ietf-dhcpv6-relay {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 relay.";
 
+  revision 2017-11-29{
+	  description "separation of relay configuration and 
+		  state trees";
+	  reference "I-d: draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated relay specific
       YANG model.";
@@ -54,319 +60,348 @@ module ietf-dhcpv6-relay {
    */
 
 container relay {
-    presence "Enables relay";
     description "dhcpv6 relay portion";
-    container relay-attributes {
-      description "A container describes
-        some basic attributes of the relay
-        agent including some relay agent
-        specific options data that need to
-        be configured previously. Such options
-        include Remote-Id option and
-        Subscriber-Id option.";
-      leaf name {
-        type string;
-        description "relay agent name";
-      }
-      leaf description {
-        type string;
-        description "description of the relay agent";
-      }
-      leaf-list dest-addrs {
-        type inet:ipv6-address;
-        description "Each DHCPv6 relay agent may
-          be configured with a list of destination
-          addresses. This node defines such a list
-          of IPv6 addresses that may include
-          unicast addresses, multicast addresses
-          or other addresses.";
-      }
-      list subscribers {
-        key subscriber;
-        description "subscribers";
-        leaf subscriber {
-          type uint8;
-          mandatory true;
-          description "subscriber";
-        }
-        leaf subscriber-id {
-          type string;
-          mandatory true;
-          description "subscriber id";
-        }
-      }
-      list remote-host {
-        key ent-num;
-        description "remote host";
-        leaf ent-num {
-          type uint32;
-          mandatory true;
-          description "enterprise number";
-        }
-        leaf remote-id {
-          type string;
-          mandatory true;
-          description "remote id";
-        }
-      }
-      uses vendor-infor;
-    }
+    
+    container relay-config{
+    	description "configuration tree of relay";
+    	
+        container relay-attributes {
+            description "A container describes
+              some basic attributes of the relay
+              agent including some relay agent
+              specific options data that need to
+              be configured previously. Such options
+              include Remote-Id option and
+              Subscriber-Id option.";
+            leaf name {
+              type string;
+              description "relay agent name";
+            }
+            leaf description {
+              type string;
+              description "description of the relay agent";
+            }
+            leaf-list dest-addrs {
+              type inet:ipv6-address;
+              description "Each DHCPv6 relay agent may
+                be configured with a list of destination
+                addresses. This node defines such a list
+                of IPv6 addresses that may include
+                unicast addresses, multicast addresses
+                or other addresses.";
+            }
+            list subscribers {
+              key subscriber;
+              description "subscribers";
+              leaf subscriber {
+                type uint8;
+                mandatory true;
+                description "subscriber";
+              }
+              leaf subscriber-id {
+                type string;
+                mandatory true;
+                description "subscriber id";
+              }
+            }
+            list remote-host {
+              key ent-num;
+              description "remote host";
+              leaf ent-num {
+                type uint32;
+                mandatory true;
+                description "enterprise number";
+              }
+              leaf remote-id {
+                type string;
+                mandatory true;
+                description "remote id";
+              }
+            }
+            uses vendor-infor;
+          }
 
-    container rsoo-option-sets {
-      list option-set {
-        key id;
-          leaf id {
-            type uint32;
+          container rsoo-option-sets {
+            list option-set {
+              key id;
+                leaf id {
+                  type uint32;
+                }
+              uses dhcpv6-options:relay-supplied-option-definitions;
+            }
           }
-        uses dhcpv6-options:relay-supplied-option-definitions;
-      }
-    }
 
-    list relay-if {
-      // if - This should reference an entry in ietf-interfaces
-      key if-name;
-      description "A relay agent may have several
-        interfaces, we should provide a way to configure
-        and manage parameters on the interface-level. A
-        list that describes specific interfaces and
-        their corresponding parameters is employed to
-        fulfil the configfuration. Here we use a string
-        called 'if-name; as the key of list.";
-      leaf if-name {
-        type string;
-        mandatory true;
-        description "interface name";
-      }
-      leaf enable {
-        type boolean;
-        mandatory true;
-        description
-          "whether this interface is enabled";
-      }
-      leaf ipv6-address {
-        type inet:ipv6-address;
-        description
-          "ipv6 address for this interface";
-      }
-      leaf interface-id {
-        type string;
-        description "interface id";
-      }
-      leaf rsoo-option-set-id {
-        type leafref {
-          path "/relay/rsoo-option-sets/option-set/id";
-        }
-        description "Configured Relay Supplied Option set";
-      }
-      list pd-route {
-        // if - need to look at if/how we model these. If they are
-        // going to be modelled, then they should be ro state
-        // entries (we're not trying to configure routes here)
-        key pd-route-id;
-        description "pd route";
-        leaf pd-route-id {
-          type uint8;
-          mandatory true;
-          description "pd route id";
-        }
-        leaf requesting-router-id {
-          type uint32;
-          mandatory true;
-          description "requesting router id";
-        }
-        leaf delegating-router-id {
-          type uint32;
-          mandatory true;
-          description "delegating router id";
-        }
-        leaf next-router {
-          type inet:ipv6-address;
-          mandatory true;
-          description "next router";
-        }
-        leaf last-router {
-          type inet:ipv6-address;
-          mandatory true;
-          description "previous router";
-        }
-      }
-      list next-entity {
-        key dest-addr;
-        description "This node defines
-          a list that is used to describe
-          the next hop entity of this
-          relay distinguished by their
-          addresses.";
-        leaf dest-addr {
-          type inet:ipv6-address;
-          mandatory true;
-          description "destination addr";
-        }
-        leaf available {
-          type boolean;
-          mandatory true;
-          description "whether the next entity
-            is available or not";
-        }
-        leaf multicast {
-          type boolean;
-          mandatory true;
-          description "whether the address is
-            multicast or not";
-        }
-        leaf server {
-          type boolean;
-          mandatory true;
-          description "whether the next entity
-            is a server";
-        }
-        container packet-stats {
-          config "false";
-          description "packet statistics";
-          leaf cli-packet-rvd-count {
-            type uint32;
-            mandatory true;
-            description "client received packet
-              counter";
+          list relay-if {
+            // if - This should reference an entry in ietf-interfaces
+            key if-name;
+            description "A relay agent may have several
+              interfaces, we should provide a way to configure
+              and manage parameters on the interface-level. A
+              list that describes specific interfaces and
+              their corresponding parameters is employed to
+              fulfil the configfuration. Here we use a string
+              called 'if-name; as the key of list.";
+            leaf if-name {
+              type string;
+              mandatory true;
+              description "interface name";
+            }
+            leaf enable {
+              type boolean;
+              mandatory true;
+              description
+                "whether this interface is enabled";
+            }
+            leaf ipv6-address {
+              type inet:ipv6-address;
+              description
+                "ipv6 address for this interface";
+            }
+            leaf interface-id {
+              type string;
+              description "interface id";
+            }
+            leaf rsoo-option-set-id {
+              type leafref {
+                path "/relay/relay-config/rsoo-option-sets/option-set/id";
+              }
+              description "Configured Relay Supplied Option set";
+            }
+            list pd-route {
+              // if - need to look at if/how we model these. If they are
+              // going to be modelled, then they should be ro state
+              // entries (we're not trying to configure routes here)
+              key pd-route-id;
+              description "pd route";
+              leaf pd-route-id {
+                type uint8;
+                mandatory true;
+                description "pd route id";
+              }
+              leaf requesting-router-id {
+                type uint32;
+                mandatory true;
+                description "requesting router id";
+              }
+              leaf delegating-router-id {
+                type uint32;
+                mandatory true;
+                description "delegating router id";
+              }
+              leaf next-router {
+                type inet:ipv6-address;
+                mandatory true;
+                description "next router";
+              }
+              leaf last-router {
+                type inet:ipv6-address;
+                mandatory true;
+                description "previous router";
+              }
+            }
+            list next-entity {
+              key dest-addr;
+              description "This node defines
+                a list that is used to describe
+                the next hop entity of this
+                relay distinguished by their
+                addresses.";
+              leaf dest-addr {
+                type inet:ipv6-address;
+                mandatory true;
+                description "destination addr";
+              }
+              leaf available {
+                type boolean;
+                mandatory true;
+                description "whether the next entity
+                  is available or not";
+              }
+              leaf multicast {
+                type boolean;
+                mandatory true;
+                description "whether the address is
+                  multicast or not";
+              }
+              leaf server {
+                type boolean;
+                mandatory true;
+                description "whether the next entity
+                  is a server";
+              }
+            }
           }
-          leaf solicit-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "solicit received counter";
-          }
-          leaf request-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "request received counter";
-          }
-          leaf renew-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "renew received counter";
-          }
-          leaf rebind-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "rebind recevied counter";
-          }
-          leaf decline-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "decline received counter";
-          }
-          leaf release-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "release received counter";
-          }
-          leaf info-req-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "information request counter";
-          }
-          leaf relay-for-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay forward received counter";
-          }
-          leaf relay-rep-rvd-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay reply received counter";
-          }
-          leaf packet-to-cli-count {
-            type uint32;
-            mandatory true;
-            description
-              "packet to client counter";
-          }
-          leaf adver-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "advertisement sent counter";
-          }
-          leaf confirm-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "confirm sent counter";
-          }
-          leaf reply-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "reply sent counter";
-          }
-          leaf reconfig-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "reconfigure sent counter";
-          }
-          leaf relay-for-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay forward sent counter";
-          }
-          leaf relay-rep-sent-count {
-            type uint32;
-            mandatory true;
-            description
-              "relay reply sent counter";
-          }
-        }
-      }
+          
+    	
     }
-    container relay-stats {
-      config "false";
-      description "relay statistics";
-      leaf cli-packet-rvd-count {
-        type uint32;
-        mandatory true;
-        description "client packet received counter";
-      }
-      leaf relay-for-rvd-count {
-        type uint32;
-        mandatory true;
-        description "relay forward received counter";
-      }
-      leaf relay-rep-rvd-count {
-        type uint32;
-        mandatory true;
-        description "relay reply recevied counter";
-      }
-      leaf packet-to-cli-count {
-        type uint32;
-        mandatory true;
-        description "packet to client counter";
-      }
-      leaf relay-for-sent-count {
-        type uint32;
-        mandatory true;
-        description "relay forward sent counter";
-      }
-      leaf relay-rep-sent-count {
-        type uint32;
-        mandatory true;
-        description "relay reply sent counter";
-      }
-      leaf discarded-packet-count {
-        type uint32;
-        mandatory true;
-        description "discarded packet counter";
-      }
-    }
+    
+    
+	container relay-state{
+		description "state tree of relay";
+		
+		config "false";
+		list relay-if{
+			key if-name;
+			description "...";			
+			leaf if-name{
+				type string;
+				mandatory true;
+				description "interface name";
+			}
+			list next-entity{
+				key dest-addr;
+				leaf dest-addr{
+					type inet:ipv6-address;
+					mandatory true;
+					description "destination addr";
+				}
+				container packet-stats {
+					description "packet statistics";
+					leaf solicit-rvd-count {
+		                  type uint32;
+		                  mandatory true;
+		                  description
+		                    "solicit received counter";
+		                }
+	                leaf request-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "request received counter";
+	                }
+	                leaf renew-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "renew received counter";
+	                }
+	                leaf rebind-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "rebind recevied counter";
+	                }
+	                leaf decline-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "decline received counter";
+	                }
+	                leaf release-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "release received counter";
+	                }
+	                leaf info-req-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "information request counter";
+	                }
+	                leaf relay-for-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay forward received counter";
+	                }
+	                leaf relay-rep-rvd-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay reply received counter";
+	                }
+	                leaf packet-to-cli-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "packet to client counter";
+	                }
+	                leaf adver-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "advertisement sent counter";
+	                }
+	                leaf confirm-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "confirm sent counter";
+	                }
+	                leaf reply-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "reply sent counter";
+	                }
+	                leaf reconfig-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "reconfigure sent counter";
+	                }
+	                leaf relay-for-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay forward sent counter";
+	                }
+	                leaf relay-rep-sent-count {
+	                  type uint32;
+	                  mandatory true;
+	                  description
+	                    "relay reply sent counter";
+	                }
+				}
+				
+			}
+		}
+		
+		
+	    container relay-stats {
+	        config "false";
+	        description "relay statistics";
+	        leaf cli-packet-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "client packet received counter";
+	        }
+	        leaf relay-for-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay forward received counter";
+	        }
+	        leaf relay-rep-rvd-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay reply recevied counter";
+	        }
+	        leaf packet-to-cli-count {
+	          type uint32;
+	          mandatory true;
+	          description "packet to client counter";
+	        }
+	        leaf relay-for-sent-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay forward sent counter";
+	        }
+	        leaf relay-rep-sent-count {
+	          type uint32;
+	          mandatory true;
+	          description "relay reply sent counter";
+	        }
+	        leaf discarded-packet-count {
+	          type uint32;
+	          mandatory true;
+	          description "discarded packet counter";
+	        }
+	      }
+		
+	}
+    
+
   }
 
   /*

--- a/ietf-dhcpv6-server@2017-11-24.yang
+++ b/ietf-dhcpv6-server@2017-11-24.yang
@@ -25,6 +25,12 @@ module ietf-dhcpv6-server {
   description "This model defines a YANG data model that can be
     used to configure and manage a DHCPv6 server.";
 
+  revision 2017-11-29 {
+	  description "First version of separation of server configuration
+		  and state trees.";
+	  reference "I-D: draft-ietf-dhc-dhcpv6-yang";
+  }
+  
   revision 2017-11-24 {
     description "First version of the separated server specific
       YANG model.";
@@ -69,699 +75,788 @@ module ietf-dhcpv6-server {
      }
    }
   }
-
+  
   grouping duid {
-    description "DHCP Unique Identifier";
-    reference "RFC3315: Section 9";
-    choice duid-type {
-      description "Selects the format for the DUID.";
-      case duid-llt {
-        description "DUID Based on Link-layer Address Plus Time";
-        reference "RFC3315 Section 9.2";
-        leaf duid-llt-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-llt-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-        leaf duid-llt-link-layer-addr {
-          type yang:mac-address;
-          description "Link-layer address as described in RFC2464";
-        }
-      }
-      case duid-en {
-        description "DUID Assigned by Vendor Based on Enterprise Number";
-        reference "RFC3315 Section 9.3";
-        leaf duid-en-enterprise-number {
-          type uint32;
-          description "Vendor's registered Private Enterprise Number as
-            maintained by IANA";
-        }
-        leaf duid-en-identifier {
-          type string;
-          description "Indentifier, unique to the device that is using it";
-        }
-      }
-      case duid-ll {
-        description "DUID Based on Link-layer Address";
-        reference "RFC3315 Section 9.4";
-        leaf duid-ll-hardware-type {
-          type uint16;
-          description "Hardware type as assigned by IANA (RFC826).";
-        }
-        leaf duid-ll-time {
-          type yang:timeticks;
-          description "The time value is the time that the DUID is generated
-            represented in seconds since midnight (UTC), January 1, 2000,
-                        modulo 2^32.";
-        }
-      }
-    }
-  }
+	    description "DHCP Unique Identifier";
+	    reference "RFC3315: Section 9";
+	    leaf type-code {
+	        	type uint16;
+	        	description "Type code of this DUID";
+	        	default 65535;
+	        }
+	    choice duid-type {
+	      description "Selects the format for the DUID.";
+	      default duid-invalid;
+	      case duid-llt {
+	        description "DUID Based on Link-layer Address Plus Time (Type 1 - DUID-LLT)";
+	        reference "RFC3315 Section 9.2";
+
+	        leaf duid-llt-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-llt-time {
+	          type yang:timeticks;
+	          description "The time value is the time that the DUID is generated
+	            represented in seconds since midnight (UTC), January 1, 2000,
+	                        modulo 2^32.";
+	        }
+	        leaf duid-llt-link-layer-addr {
+	          type yang:mac-address;
+	          description "Link-layer address as described in RFC2464";
+	        }
+	      }
+	      case duid-en {
+	        description "DUID Assigned by Vendor Based on Enterprise Number (Type 2 - DUID-EN)";
+	        reference "RFC3315 Section 9.3";
+	        leaf duid-en-enterprise-number {
+	          type uint32;
+	          description "Vendor's registered Private Enterprise Number as
+	            maintained by IANA";
+	        }
+	        leaf duid-en-identifier {
+	          type string;
+	          description "Indentifier, unique to the device that is using it";
+	        }
+	      }
+	      case duid-ll {
+	        description "DUID Based on Link-layer Address (Type 3 - DUID-LL)";
+	        reference "RFC3315 Section 9.4";
+	        leaf duid-ll-hardware-type {
+	          type uint16;
+	          description "Hardware type as assigned by IANA (RFC826).";
+	        }
+	        leaf duid-ll-link-layer-addr {
+		          type yang:mac-address;
+		          description "Link-layer address as described in RFC2464";
+		    }
+	      }
+	      case duid-uuid {
+	    	  description "DUID Based on Universally Unique Identifier (Type 4 - DUID-UUID)";
+	    	  reference "RFC6335 Defination of the UUID-Based Unique Identifier";
+	    	  leaf uuid {
+	    		  type yang:uuid;
+	    		  description "A Universally Unique IDentifier in the string representation
+	    		      defined in RFC 4122.  The canonical representation uses
+	    		      lowercase characters";
+	    	  }    	  
+	      }
+	      case duid-invalid {
+	    	  description "DUID based on free raw bytes";
+	    	  leaf data {
+	    		  type binary;
+	    		  description "The bits to be used as the identifier";
+	    	  }
+	      }	      
+	    }
+	  }
 
   /*
    * Data Nodes
    */
 
   container server {
-    presence "Enables server";
     description "dhcpv6 server portion";
-    container serv-attributes {
-      description "This container contains basic attributes
-        of a DHCPv6 server such as DUID, server name and so
-        on. Some optional functions that can be provided by
-        the server is also included.";
-      leaf name {
-        type string;
-        description "server's name";
-      }
-      container duid {
-        description "Sets the DUID";
-        uses duid;
-      }
-      leaf-list ipv6-address {
-        type inet:ipv6-address;
-        description "Server's IPv6 address.";
-      }
-      leaf description {
-        type string;
-        description "Description of the server.";
-      }
-      leaf pd-function {
-        type boolean;
-        mandatory true;
-        description "Whether the server can act as a
-          delegating router to perform prefix delegation
-          ([RFC3633]).";
-      }
-      leaf stateless-service {
-        type boolean;
-        mandatory true;
-        description "A boolean value specifies whether
-          the server support client-server exchanges
-          involving two messages defined in ([RFC3315]).";
-      }
-      leaf rapid-commit {
-        type boolean;
-        mandatory true;
-        description "A boolean value specifies whether
-          the server support client-server exchanges
-          involving two messages defined in ([RFC3315]).";
-      }
-      leaf-list interfaces-config {
-        // Note - this should probably be references to
-        // entries in the ietf-interfaces model
-        type string;
-        description "A leaf list to denote which one or
-          more interfaces the server should listen on. The
-          default value is to listen on all the interfaces.
-          This node is also used to set a unicast address
-          for the server to listen with a specific interface.
-            For example, if people want the server to listen
-              on a unicast address with a specific interface, he
-              can use the format like 'eth1/2001:db8::1'.";
-      }
-      uses vendor-infor;
-    }
+    
+    /*configuration data*/
+    container server-config{
+    	description "configuration tree of server";
+    	   container serv-attributes {
+    		      description "This container contains basic attributes
+    		        of a DHCPv6 server such as DUID, server name and so
+    		        on. Some optional functions that can be provided by
+    		        the server is also included.";
+    		      leaf name {
+    		        type string;
+    		        description "server's name";
+    		      }
+    		      container duid {
+    		        description "Sets the DUID";
+    		        uses duid;
+    		      }
+    		      leaf-list ipv6-address {
+    		        type inet:ipv6-address;
+    		        description "Server's IPv6 address.";
+    		      }
+    		      leaf description {
+    		        type string;
+    		        description "Description of the server.";
+    		      }
+    		      leaf pd-function {
+    		        type boolean;
+    		        mandatory true;
+    		        description "Whether the server can act as a
+    		          delegating router to perform prefix delegation
+    		          ([RFC3633]).";
+    		      }
+    		      leaf stateless-service {
+    		        type boolean;
+    		        mandatory true;
+    		        description "A boolean value specifies whether
+    		          the server support client-server exchanges
+    		          involving two messages defined in ([RFC3315]).";
+    		      }
+    		      leaf rapid-commit {
+    		        type boolean;
+    		        mandatory true;
+    		        description "A boolean value specifies whether
+    		          the server support client-server exchanges
+    		          involving two messages defined in ([RFC3315]).";
+    		      }
+    		      leaf-list interfaces-config {
+    		        // Note - this should probably be references to
+    		        // entries in the ietf-interfaces model
+    		        type string;
+    		        description "A leaf list to denote which one or
+    		          more interfaces the server should listen on. The
+    		          default value is to listen on all the interfaces.
+    		          This node is also used to set a unicast address
+    		          for the server to listen with a specific interface.
+    		            For example, if people want the server to listen
+    		              on a unicast address with a specific interface, he
+    		              can use the format like 'eth1/2001:db8::1'.";
+    		      }
+    		      uses vendor-infor;
+    		    }
+    	
+    	    container option-sets {
+    	        list option-set {
+    	          key id;
+    	            leaf id {
+    	              type uint32;
+    	            }
+    	          uses dhcpv6-options:server-option-definitions;
+    	          uses dhcpv6-options:custom-option-definitions;
+    	        }
+    	      }
 
-    container option-sets {
-      list option-set {
-        key id;
-          leaf id {
-            type uint32;
-          }
-        uses dhcpv6-options:server-option-definitions;
-        uses dhcpv6-options:custom-option-definitions;
-      }
+    	      container network-ranges {
+    	        description "This model supports a hierarchy
+    	          to achieve dynamic configuration. That is to
+    	          say we could configure the server at different
+    	          levels through this model. The top level is a
+    	          global level which is defined as the container
+    	          'network-ranges'. The following levels are
+    	          defined as sub-containers under it. The
+    	          'network-ranges' contains the parameters
+    	          (e.g. option-sets) that would be allocated to
+    	          all the clients served by this server.";
+    	        list network-range {
+    	          key network-range-id;
+    	          description "Under the 'network-ranges'
+    	            container, a 'network-range' list is
+    	            defined to configure the server at a
+    	            network level which is also considered
+    	            as the second level. Different network
+    	            are identified by the key 'network-range-id'.
+    	            This is because a server may have different
+    	            configuration parameters (e.g. option sets)
+    	            for different networks.";
+    	          leaf network-range-id {
+    	            type uint32;
+    	            mandatory true;
+    	            description "equivalent to subnet id";
+    	          }
+    	          leaf network-description {
+    	            type string;
+    	            mandatory true;
+    	            description "description of the subnet";
+    	          }
+    	          leaf network-prefix {
+    	            type inet:ipv6-prefix;
+    	            mandatory true;
+    	            description "subnet prefix";
+    	          }
+    	          leaf inherit-option-set {
+    	            type boolean;
+    	            mandatory true;
+    	            description "indicate whether to inherit
+    	              the configuration from higher level";
+    	          }
+    	          leaf option-set-id {
+    	            type leafref {
+    	              path "/server/server-config/option-sets/option-set/id";
+    	            }
+    	            description "The ID field of relevant option-set to be
+    	              provisioned to clients of this network-range.";
+    	          }
+    	        }
+    	          container reserved-addresses {
+    	            description "reserved addresses";
+    	            list static-binding {
+    	              key cli-id;
+    	              description "static binding of
+    	                reserved addresses";
+    	              leaf cli-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "client id";
+    	              }
+    	              container duid {
+    	                description "Sets the DUID";
+    	                uses duid;
+    	              }
+    	              leaf-list reserv-addr {
+    	                type inet:ipv6-address;
+    	                description "reserved addr";
+    	              }
+    	            }
+    	            leaf-list other-reserv-addr {
+    	              type inet:ipv6-address;
+    	              description "other reserved
+    	                addr";
+    	            }
+    	          }
+    	          container reserved-prefixes {
+    	            description "reserved prefixes";
+    	            list static-binding {
+    	              key cli-id;
+    	              description "static binding";
+    	              leaf cli-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "client id";
+    	              }
+    	              container duid {
+    	                description "Sets the DUID";
+    	                uses duid;
+    	              }
+    	              leaf reserv-prefix-len {
+    	                type uint8;
+    	                mandatory true;
+    	                description "reserved
+    	                  prefix length";
+    	              }
+    	              leaf reserv-prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix";
+    	              }
+    	            }
+    	            leaf exclude-prefix-len {
+    	              type uint8;
+    	              mandatory true;
+    	              description "exclude prefix
+    	                length";
+    	            }
+    	            leaf exclude-prefix {
+    	              type inet:ipv6-prefix;
+    	              mandatory true;
+    	              description "exclude prefix";
+    	            }
+    	            list other-reserv-prefix {
+    	              key reserv-id;
+    	              description
+    	                "other reserved prefix";
+    	              leaf reserv-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix id";
+    	              }
+    	              leaf prefix-len {
+    	                type uint8;
+    	                mandatory true;
+    	                description "prefix length";
+    	              }
+    	              leaf prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description
+    	                  "reserved prefix";
+    	              }
+    	            }
+    	          }
+    	          container address-pools {
+    	            description "A container describes
+    	              the DHCPv6 server's address pools.";
+    	            list address-pool {
+    	              key pool-id;
+    	              description "A DHCPv6 server can
+    	                be configured with several address
+    	                pools. This list defines such
+    	                address pools which are distinguish
+    	                by the key called 'pool-name'.";
+    	              leaf pool-id {
+    	                type uint32;
+    	                mandatory true;
+    	                description "pool id";
+    	              }
+    	              leaf pool-prefix {
+    	                type inet:ipv6-prefix;
+    	                mandatory true;
+    	                description "pool prefix";
+    	              }
+    	              leaf start-address {
+    	                type inet:ipv6-address-no-zone;
+    	                mandatory true;
+    	                description "start address";
+    	              }
+    	              leaf end-address {
+    	                type inet:ipv6-address-no-zone;
+    	                mandatory true;
+    	                description "end address";
+    	              }
+    	              leaf renew-time {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "renew time";
+    	              }
+    	              leaf rebind-time {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "rebind time";
+    	              }
+    	              leaf preferred-lifetime {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "preferred lifetime
+    	                  for IA";
+    	              }
+    	              leaf valid-lifetime {
+    	                type yang:timeticks;
+    	                mandatory true;
+    	                description "valid liftime for IA";
+    	              }
+    	              leaf max-address-utilization-ratio {
+    	                type threshold;
+    	                mandatory true;
+    	                description "address utilization ratio threshold";
+    	              }
+    	              leaf inherit-option-set {
+    	                type boolean;
+    	                mandatory true;
+    	                description "indicate whether to
+    	                  inherit the configuration from
+    	                  higher level";
+    	              }
+    	              leaf option-set-id {
+    	                type leafref {
+    	                	path "/server/server-config/option-sets/option-set/id";
+    	                }
+    	                mandatory true;
+    	                description "The ID field of relevant option-set to be
+    	                  provisioned to clients of this address-pool.";
+    	              }
+    	          }    	               	                	            
+    	        }
+    	          
+    	          container prefix-pools {
+      	            description "If a server supports prefix
+      	              delegation function, this container will
+      	              be used to define the delegating router's
+      	              refix pools.";
+      	            list prefix-pool {
+      	              key pool-id;
+      	              description "Similar to server's
+      	                address pools, a delegating router
+      	                can also be configured with multiple
+      	                prefix pools specified by a list
+      	                called 'prefix-pool'.";
+      	              leaf pool-id {
+      	                type uint32;
+      	                mandatory true;
+      	                description "pool id";
+      	              }
+      	              leaf prefix {
+      	            	  
+      	                type inet:ipv6-prefix;
+      	                mandatory true;
+      	                description "ipv6 prefix";
+      	              }
+      	              leaf prefix-length {
+      	                type uint8;
+      	                mandatory true;
+      	                description "prefix length";
+      	              }
+      	              leaf renew-time {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "renew time";
+      	              }
+      	              leaf rebind-time {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "rebind time";
+      	              }
+      	              leaf preferred-lifetime {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "preferred lifetime for
+      	                  IA";
+      	              }
+      	              leaf valid-lifetime {
+      	                type yang:timeticks;
+      	                mandatory true;
+      	                description "valid lifetime for IA";
+      	              }
+      	              leaf max-prefix-utilization-ratio {
+      	                type threshold;
+      	                mandatory true;
+      	                description "prefix pool utilization ratio threshold";
+      	              }
+      	              leaf inherit-option-set {
+      	                type boolean;
+      	                mandatory true;
+      	                description "whether to inherit
+      	                  configuration from higher level";
+      	              }
+      	              leaf option-set-id {
+      	                type leafref {
+      	                	path "/server/server-config/option-sets/option-set/id";
+      	                }
+      	                description "The ID field of relevant option-set to be
+      	                  provisioned to clients of this prefix-pool.";
+      	              }
+      	            }
+      	          }
+      	          container hosts {
+      	            description "hosts level";
+      	            list host {
+      	              key cli-id;
+      	              description "specific host";
+      	              leaf cli-id {
+      	                type uint32;
+      	                mandatory true;
+      	                description "client id";
+      	              }
+      	              container duid {
+      	                description "Sets the DUID";
+      	                uses duid;
+      	              }
+      	              leaf inherit-option-set {
+      	                type boolean;
+      	                mandatory true;
+      	                description "whether to inherit
+      	                  configuration
+      	                  from higher level";
+      	              }
+      	              leaf option-set-id {
+      	                type leafref {
+      	                	path "/server/server-config/option-sets/option-set/id";
+      	                }
+      	                description "The ID field of relevant option-set to be
+      	                  provisioned to clients of this prefix-pool.";
+      	              }
+      	              leaf nis-domain-name {
+      	                type string;
+      	                description "nis domain name";
+      	              }
+      	              leaf nis-plus-domain-name {
+      	                type string;
+      	                description "nisp domain name";
+      	              }
+      	            }
+      	          }
+    	      }
+    	      container relay-opaque-paras {
+    	        description "This container contains some
+    	          opaque values in Relay Agent options that
+    	          need to be configured on the server side
+    	          only for value match. Such Relay Agent
+    	          options include Interface-Id option,
+    	                  Remote-Id option and Subscriber-Id option.";
+    	        list relays {
+    	          key relay-name;
+    	          description "relay agents";
+    	          leaf relay-name {
+    	            type string;
+    	            mandatory true;
+    	            description "relay agent name";
+    	          }
+    	          list interface-info {
+    	            key if-name;
+    	            description "interface info";
+    	            leaf if-name {
+    	              type string;
+    	              mandatory true;
+    	              description "interface name";
+    	            }
+    	            leaf interface-id {
+    	              type string;
+    	              mandatory true;
+    	              description "interface id";
+    	            }
+    	          }
+    	          list subscribers {
+    	            key subscriber;
+    	            description "subscribers";
+    	            leaf subscriber {
+    	              type uint32;
+    	              mandatory true;
+    	              description "subscriber";
+    	            }
+    	            leaf subscriber-id {
+    	              type string;
+    	              mandatory true;
+    	              description "subscriber id";
+    	            }
+    	          }
+    	          list remote-host {
+    	            key ent-num;
+    	            description "remote host";
+    	            leaf ent-num {
+    	              type uint32;
+    	              mandatory true;
+    	              description "enterprise number";
+    	            }
+    	            leaf remote-id {
+    	              type string;
+    	              mandatory true;
+    	              description "remote id";
+    	            }
+    	          }
+    	        }
+    	      }
+    	      container rsoo-enabled-options {
+    	        description "rsoo enabled options";
+    	        list rsoo-enabled-option{
+    	          key option-code;
+    	          description "rsoo enabled option";
+    	          leaf option-code {
+    	            type uint16;
+    	            mandatory true;
+    	            description "option code";
+    	          }
+    	          leaf description {
+    	            type string;
+    	            mandatory true;
+    	            description "description of the option";
+    	          }
+    	        }
+    	      }
+    	
     }
+      
+    /*State data*/
+    container server-state{
+    	config "false";
+    	description "states of server";
+    	 	
+    	container network-ranges{   		
+    		list network-range{
+    			key network-range-id;
+    			leaf network-range-id {
+    	            type uint32;
+    	            mandatory true;
+    	            description "equivalent to subnet id";
+    	          }
+  	            description "The ID field of relevant option-set to be
+  	              provisioned to clients of this network-range.";  	              			
+        		container address-pools{
+        			description "A container that describes
+        				the DHCPv6 server's address pools";   			
+            		list address-pool{
+            			key pool-id;
+    	              	leaf pool-id {
+        	                type uint32;
+        	                mandatory true;
+        	                description "pool id";
+        	              }
+            			description "...";
+            			leaf total-ipv6-count{
+            				type uint64;
+            				mandatory true;
+            				description "how many ipv6 addresses
+            					are in the pool";
+            			}
+            			leaf used-ipv6-count{
+            				type uint64;
+            				mandatory true;
+            				description "how many are allocated";
+            			}
+            			leaf address-utilization-ratio{
+            				type uint16;
+            				mandatory true;
+            				description "current address pool utilization ratio";
+            			}
+            		}
+            		list binding-info {
+            			key cli-id;
+            			description "A list that records a binding
+            				information for each DHCPv6 client 
+            				that has already been allocated 
+            				IPv6 addresses.";
+            			leaf cli-id{
+            				type uint32;
+            				mandatory true;
+            				description "client id";
+            				
+            			}
+            			container duid {
+            				description "Read the DUID";
+            				uses duid;
+            			}
+            			list cli-ia{
+            				key iaid;
+            				description "client IA";
+            				leaf ia-type{
+            					type string;
+            					mandatory true;
+            					description "IA type";
+            				}
+            				leaf iaid{
+            					type uint32;
+            					mandatory true;
+            					description "IAID";
+            				}
+            				leaf-list cli-addr{
+            					type inet:ipv6-address;
+            					description "client addr";
+            				}
+            				leaf pool-id{
+            					type uint32;
+            					mandatory true;
+            					description "pool id";
+            				}
+            			}
+            		}
+        		}    		
+        		container prefix-pools{
+        			description "If a server supports prefix
+        				delegation function, this container will
+        				be used to define the delegating router's 
+        				prefix pools.";
+        			list prefix-pool {
+        	              key pool-id;
+        	              description "Similar to server's
+        	                address pools, a delegating router
+        	                can also be configured with multiple
+        	                prefix pools specified by a list
+        	                called 'prefix-pool'.";
+        	              leaf pool-id {
+            	               type uint32;  
+        	            	  mandatory true;
+            	                description "pool id";
+            	              }
+              			leaf prefix-utilization-ratio{
+            				type uint16;
+            				mandatory true;
+            				description "current prefix pool utilization ratio";
+            			}
+        			}
 
-    container network-ranges {
-      description "This model supports a hierarchy
-        to achieve dynamic configuration. That is to
-        say we could configure the server at different
-        levels through this model. The top level is a
-        global level which is defined as the container
-        'network-ranges'. The following levels are
-        defined as sub-containers under it. The
-        'network-ranges' contains the parameters
-        (e.g. option-sets) that would be allocated to
-        all the clients served by this server.";
-      list network-range {
-        key network-range-id;
-        description "Under the 'network-ranges'
-          container, a 'network-range' list is
-          defined to configure the server at a
-          network level which is also considered
-          as the second level. Different network
-          are identified by the key 'network-range-id'.
-          This is because a server may have different
-          configuration parameters (e.g. option sets)
-          for different networks.";
-        leaf network-range-id {
-          type uint32;
-          mandatory true;
-          description "equivalent to subnet id";
-        }
-        leaf network-description {
-          type string;
-          mandatory true;
-          description "description of the subnet";
-        }
-        leaf network-prefix {
-          type inet:ipv6-prefix;
-          mandatory true;
-          description "subnet prefix";
-        }
-        leaf inherit-option-set {
-          type boolean;
-          mandatory true;
-          description "indicate whether to inherit
-            the configuration from higher level";
-        }
-        leaf option-set-id {
-          type leafref {
-            path "/server/option-sets/option-set/id";
-          }
-          description "The ID field of relevant option-set to be
-            provisioned to clients of this network-range.";
-        }
-      }
-        container reserved-addresses {
-          description "reserved addresses";
-          list static-binding {
-            key cli-id;
-            description "static binding of
-              reserved addresses";
-            leaf cli-id {
+        			list binding-info{
+        				key cli-id;
+        				description "A list records a binding
+        					information for each DHCPv6 client
+        					that has already been alloated IPv6
+        					addresses.";
+        				leaf cli-id{
+        					type uint32;   
+        					mandatory true;
+        					description "client id";
+        				}
+        				container duid{
+        					description "Reads the DUID";
+        					uses duid;
+        				}
+        				list cli-iapd{
+        					key iaid;
+        					description "client IAPD";
+        					leaf iaid{
+        						type uint32;
+        						mandatory true;
+        						description "IAID";
+        					}   					
+        					leaf-list cli-prefix {
+        						type inet:ipv6-prefix;
+        						description "client ipv6 prefix";
+        					}    					
+        					leaf-list cli-prefix-len{
+        						type uint8;
+        						description "client prefix length";
+        					}    					
+        					leaf pool-id{
+        						type uint32;
+        						mandatory true;
+        						description "pool id";
+        					}
+        					
+        				}
+        			}
+        		}    
+    		}
+    		}
+		    		
+    	
+    	
+        container packet-stats {
+              description "A container presents
+              the packet statistics related to
+              the DHCPv6 server.";
+            leaf solicit-count {
               type uint32;
               mandatory true;
-              description "client id";
+              description "solicit counter";
             }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf-list reserv-addr {
-              type inet:ipv6-address;
-              description "reserved addr";
-            }
-          }
-          leaf-list other-reserv-addr {
-            type inet:ipv6-address;
-            description "other reserved
-              addr";
-          }
-        }
-        container reserved-prefixes {
-          description "reserved prefixes";
-          list static-binding {
-            key cli-id;
-            description "static binding";
-            leaf cli-id {
+            leaf request-count {
               type uint32;
               mandatory true;
-              description "client id";
+              description "request counter";
             }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf reserv-prefix-len {
-              type uint8;
-              mandatory true;
-              description "reserved
-                prefix length";
-            }
-            leaf reserv-prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description
-                "reserved prefix";
-            }
-          }
-          leaf exclude-prefix-len {
-            type uint8;
-            mandatory true;
-            description "exclude prefix
-              length";
-          }
-          leaf exclude-prefix {
-            type inet:ipv6-prefix;
-            mandatory true;
-            description "exclude prefix";
-          }
-          list other-reserv-prefix {
-            key reserv-id;
-            description
-              "other reserved prefix";
-            leaf reserv-id {
+            leaf renew-count {
               type uint32;
               mandatory true;
-              description
-                "reserved prefix id";
+              description "renew counter";
             }
-            leaf prefix-len {
-              type uint8;
+            leaf rebind-count {
+              type uint32;
               mandatory true;
-              description "prefix length";
+              description "rebind counter";
             }
-            leaf prefix {
-              type inet:ipv6-prefix;
+            leaf decline-count {
+              type uint32;
               mandatory true;
-              description
-                "reserved prefix";
+              description "decline count";
+            }
+            leaf release-count {
+              type uint32;
+              mandatory true;
+              description "release counter";
+            }
+            leaf info-req-count {
+              type uint32;
+              mandatory true;
+              description "information request
+                counter";
+            }
+            leaf advertise-count {
+              type uint32;
+              mandatory true;
+              description "advertise counter";
+            }
+            leaf confirm-count {
+              type uint32;
+              mandatory true;
+              description "confirm counter";
+            }
+            leaf reply-count {
+              type uint32;
+              mandatory true;
+              description "reply counter";
+            }
+            leaf reconfigure-count {
+              type uint32;
+              mandatory true;
+              description "reconfigure counter";
+            }
+            leaf relay-forward-count {
+              type uint32;
+              mandatory true;
+              description "relay forward counter";
+            }
+            leaf relay-reply-count {
+              type uint32;
+              mandatory true;
+              description "relay reply counter";
             }
           }
         }
-        container address-pools {
-          description "A container describes
-            the DHCPv6 server's address pools.";
-          list address-pool {
-            key pool-id;
-            description "A DHCPv6 server can
-              be configured with several address
-              pools. This list defines such
-              address pools which are distinguish
-              by the key called 'pool-name'.";
-            leaf pool-id {
-              type uint32;
-              mandatory true;
-              description "pool id";
-            }
-            leaf pool-prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description "pool prefix";
-            }
-            leaf start-address {
-              type inet:ipv6-address-no-zone;
-              mandatory true;
-              description "start address";
-            }
-            leaf end-address {
-              type inet:ipv6-address-no-zone;
-              mandatory true;
-              description "end address";
-            }
-            leaf renew-time {
-              type yang:timeticks;
-              mandatory true;
-              description "renew time";
-            }
-            leaf rebind-time {
-              type yang:timeticks;
-              mandatory true;
-              description "rebind time";
-            }
-            leaf preferred-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "preferred lifetime
-                for IA";
-            }
-            leaf valid-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "valid liftime for IA";
-            }
-            leaf total-ipv6-count {
-              type uint64;
-              config "false";
-              mandatory true;
-              description "how many ipv6
-                addressses are in the pool";
-            }
-            leaf used-ipv6-count {
-              type uint64;
-              config "false";
-              mandatory true;
-              description "how many are
-                allocated";
-            }
-            leaf utilization-ratio {
-              type threshold;
-              mandatory true;
-              description "the utilization ratio";
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "indicate whether to
-                inherit the configuration from
-                higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
-              }
-              mandatory true;
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this address-pool.";
-            }
-          list binding-info {
-            key cli-id;
-            config "false";
-            description "A list records a binding
-              information for each DHCPv6 client
-              that has already been allocated IPv6
-              addresses.";
-            leaf cli-id {
-              type uint32;
-              mandatory true;
-              description "client id";
-            }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            list cli-ia {
-              key iaid;
-              description "client IA";
-              leaf ia-type {
-                type string;
-                mandatory true;
-                description "IA type";
-              }
-              leaf iaid {
-                type uint32;
-                mandatory true;
-                description "IAID";
-              }
-              leaf-list cli-addr {
-                type inet:ipv6-address;
-                description "client addr";
-              }
-              leaf pool-id {
-                type uint32;
-                mandatory true;
-                description "pool id";
-              }
-            }
-          }
-        }
-        container prefix-pools {
-          description "If a server supports prefix
-            delegation function, this container will
-            be used to define the delegating router's
-            refix pools.";
-          list prefix-pool {
-            key pool-id;
-            description "Similar to server's
-              address pools, a delegating router
-              can also be configured with multiple
-              prefix pools specified by a list
-              called 'prefix-pool'.";
-            leaf pool-id {
-              type uint32;
-              mandatory true;
-              description "pool id";
-            }
-            leaf prefix {
-              type inet:ipv6-prefix;
-              mandatory true;
-              description "ipv6 prefix";
-            }
-            leaf prefix-length {
-              type uint8;
-              mandatory true;
-              description "prefix length";
-            }
-            leaf renew-time {
-              type yang:timeticks;
-              mandatory true;
-              description "renew time";
-            }
-            leaf rebind-time {
-              type yang:timeticks;
-              mandatory true;
-              description "rebind time";
-            }
-            leaf preferred-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "preferred lifetime for
-                IA";
-            }
-            leaf valid-lifetime {
-              type yang:timeticks;
-              mandatory true;
-              description "valid lifetime for IA";
-            }
-            leaf utilization-ratio {
-              type threshold;
-              mandatory true;
-              description "utilization ratio";
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "whether to inherit
-                configuration from higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
-              }
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this prefix-pool.";
-            }
-          }
-          list binding-info {
-            key cli-id;
-            config "false";
-            description "A list records a
-              binding information for each
-              DHCPv6 client that has already
-              been allocated IPv6 addresses.";
-            leaf cli-id {
-              type uint32;
-              mandatory true;
-              description "client id";
-            }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            list cli-iapd {
-              key iaid;
-              description "client IAPD";
-              leaf iaid {
-                type uint32;
-                mandatory true;
-                description "IAID";
-              }
-              leaf-list cli-prefix {
-                type inet:ipv6-prefix;
-                description
-                  "client ipv6 prefix";
-              }
-              leaf-list cli-prefix-len {
-                type uint8;
-                description
-                  "client prefix length";
-              }
-              leaf pool-id {
-                type uint32;
-                mandatory true;
-                description "pool id";
-              }
-            }
-          }
-        }
-        container hosts {
-          description "hosts level";
-          list host {
-            key cli-id;
-            description "specific host";
-            leaf cli-id {
-              type uint32;
-              mandatory true;
-              description "client id";
-            }
-            container duid {
-              description "Sets the DUID";
-              uses duid;
-            }
-            leaf inherit-option-set {
-              type boolean;
-              mandatory true;
-              description "whether to inherit
-                configuration
-                from higher level";
-            }
-            leaf option-set-id {
-              type leafref {
-                path "/server/option-sets/option-set/id";
-              }
-              description "The ID field of relevant option-set to be
-                provisioned to clients of this prefix-pool.";
-            }
-            leaf nis-domain-name {
-              type string;
-              description "nis domain name";
-            }
-            leaf nis-plus-domain-name {
-              type string;
-              description "nisp domain name";
-            }
-          }
-        }
-      }
     }
-    container relay-opaque-paras {
-      description "This container contains some
-        opaque values in Relay Agent options that
-        need to be configured on the server side
-        only for value match. Such Relay Agent
-        options include Interface-Id option,
-                Remote-Id option and Subscriber-Id option.";
-      list relays {
-        key relay-name;
-        description "relay agents";
-        leaf relay-name {
-          type string;
-          mandatory true;
-          description "relay agent name";
-        }
-        list interface-info {
-          key if-name;
-          description "interface info";
-          leaf if-name {
-            type string;
-            mandatory true;
-            description "interface name";
-          }
-          leaf interface-id {
-            type string;
-            mandatory true;
-            description "interface id";
-          }
-        }
-        list subscribers {
-          key subscriber;
-          description "subscribers";
-          leaf subscriber {
-            type uint32;
-            mandatory true;
-            description "subscriber";
-          }
-          leaf subscriber-id {
-            type string;
-            mandatory true;
-            description "subscriber id";
-          }
-        }
-        list remote-host {
-          key ent-num;
-          description "remote host";
-          leaf ent-num {
-            type uint32;
-            mandatory true;
-            description "enterprise number";
-          }
-          leaf remote-id {
-            type string;
-            mandatory true;
-            description "remote id";
-          }
-        }
-      }
-    }
-    container rsoo-enabled-options {
-      description "rsoo enabled options";
-      list rsoo-enabled-option{
-        key option-code;
-        description "rsoo enabled option";
-        leaf option-code {
-          type uint16;
-          mandatory true;
-          description "option code";
-        }
-        leaf description {
-          type string;
-          mandatory true;
-          description "description of the option";
-        }
-      }
-    }
-    container packet-stats {
-      config "false";
-      description "A container presents
-        the packet statistics related to
-        the DHCPv6 server.";
-      leaf solicit-count {
-        type uint32;
-        mandatory true;
-        description "solicit counter";
-      }
-      leaf request-count {
-        type uint32;
-        mandatory true;
-        description "request counter";
-      }
-      leaf renew-count {
-        type uint32;
-        mandatory true;
-        description "renew counter";
-      }
-      leaf rebind-count {
-        type uint32;
-        mandatory true;
-        description "rebind counter";
-      }
-      leaf decline-count {
-        type uint32;
-        mandatory true;
-        description "decline count";
-      }
-      leaf release-count {
-        type uint32;
-        mandatory true;
-        description "release counter";
-      }
-      leaf info-req-count {
-        type uint32;
-        mandatory true;
-        description "information request
-          counter";
-      }
-      leaf advertise-count {
-        type uint32;
-        mandatory true;
-        description "advertise counter";
-      }
-      leaf confirm-count {
-        type uint32;
-        mandatory true;
-        description "confirm counter";
-      }
-      leaf reply-count {
-        type uint32;
-        mandatory true;
-        description "reply counter";
-      }
-      leaf reconfigure-count {
-        type uint32;
-        mandatory true;
-        description "reconfigure counter";
-      }
-      leaf relay-forward-count {
-        type uint32;
-        mandatory true;
-        description "relay forward counter";
-      }
-      leaf relay-reply-count {
-        type uint32;
-        mandatory true;
-        description "relay reply counter";
-      }
-    }
-  }
-
+    
+    
   /*
    * Notifications
    */
@@ -776,11 +871,26 @@ module ietf-dhcpv6-server {
           been defined in the server feature so that it will notify the
           administrator when the utilization ratio reaches the
           threshold, and such threshold is a settable parameter";
-        leaf utilization-ratio {
+        leaf max-address-utilization-ratio {
           type uint16;
           mandatory true;
-          description "utilization ratio";
+          description "address pool utilization ratio threshold";
         }
+		leaf address-utilization-ratio{
+			type uint16;
+			mandatory true;
+			description "current address pool utilization ratio";
+		}
+		leaf max-prefix-utilization-ratio {
+	          type uint16;
+	          mandatory true;
+	          description "prefix pool utilization ratio threshold";
+	        }
+		leaf prefix-utilization-ratio{
+			type uint16;
+			mandatory true;
+			description "current prefix pool utilization ratio";
+		}
         container duid {
           description "Sets the DUID";
           uses duid;


### PR DESCRIPTION
Hi, Here are the mainly changes.
  - re-modeled DUID as discussed in the mailing list. And it needs to further revise according to the mailing list.
  - I think DUID needs to be added to 'options', instead of being moved. 'DUID' under 'server/client' is an internal attribute and every server/client must have one. I think it is different from the 'DUID-option', which is optional.
  - I differentiate between 'max utilization ratio (threshold, rw)' and 'utilization ratio (uint16, ro)'. I think it is a way to define the comparison logic.
 - Further revised and modeled some options. But there still much to do.

